### PR TITLE
Add target shape to KerasPredict Component

### DIFF
--- a/xai_components/xai_learning/tf_keras.py
+++ b/xai_components/xai_learning/tf_keras.py
@@ -1,7 +1,6 @@
 from tensorflow.keras import applications
 from tensorflow.keras.preprocessing import image
 import numpy as np
-import itertools
 
 from xai_components.base import InArg, OutArg, Component
 import json
@@ -184,8 +183,6 @@ class KerasPredict(Component):
                 if len(self.target_shape.value) != 2:
                     raise AssertionError(f"Expected two values (height and width) as target shape, got {len(self.target_shape.value)}")
             target_shape = self.target_shape.value if self.target_shape.value else model.input_shape[1:3]
-            if isinstance(target_shape, int):
-                target_shape = tuple(itertools.repeat(target_shape, 2))
             img = image.load_img(img_path, target_size=target_shape)
             x = image.img_to_array(img)
             x = np.expand_dims(x, axis=0)

--- a/xai_components/xai_learning/tf_keras.py
+++ b/xai_components/xai_learning/tf_keras.py
@@ -86,12 +86,14 @@ class KerasPredict(Component):
     model:InArg[any]
     img_string: InArg[str]
     class_list: InArg[any]
+    target_shape: InArg[tuple]
 
     def __init__(self):
         self.done = False
         self.model = InArg(None)
         self.img_string = InArg(None)
         self.class_list = InArg(None)
+        self.target_shape = InArg(None)
 
     def execute(self) -> None:
         model = self.model.value
@@ -177,7 +179,7 @@ class KerasPredict(Component):
             print(f"Auto adjusting according to model input.\n")
 
             # expected input_shape => (None, 256, 256, 3)
-            target_shape = model.input_shape[1:3]
+            target_shape = self.target_shape.value if self.target_shape.value else model.input_shape[1:3]
             img = image.load_img(img_path, target_size=target_shape)
             x = image.img_to_array(img)
             x = np.expand_dims(x, axis=0)

--- a/xai_components/xai_learning/tf_keras.py
+++ b/xai_components/xai_learning/tf_keras.py
@@ -1,6 +1,7 @@
 from tensorflow.keras import applications
 from tensorflow.keras.preprocessing import image
 import numpy as np
+import itertools
 
 from xai_components.base import InArg, OutArg, Component
 import json
@@ -179,7 +180,12 @@ class KerasPredict(Component):
             print(f"Auto adjusting according to model input.\n")
 
             # expected input_shape => (None, 256, 256, 3)
+            if isinstance(self.target_shape.value, tuple):
+                if len(self.target_shape.value) != 2:
+                    raise AssertionError(f"Expected two values (height and width) as target shape, got {len(self.target_shape.value)}")
             target_shape = self.target_shape.value if self.target_shape.value else model.input_shape[1:3]
+            if isinstance(target_shape, int):
+                target_shape = tuple(itertools.repeat(target_shape, 2))
             img = image.load_img(img_path, target_size=target_shape)
             x = image.img_to_array(img)
             x = np.expand_dims(x, axis=0)


### PR DESCRIPTION
This allows the user to specify the target shape of the image when reading it from the file. If none is specified, it will infer the shape from the model's input shape.