### PR TITLE
Force focus on the xpipes editor when a user clicks on it

### DIFF
--- a/src/xpipeWidget.tsx
+++ b/src/xpipeWidget.tsx
@@ -166,15 +166,23 @@ export class XPipePanel extends ReactWidget {
       // force focus on the editor in order stop key event propagation (e.g. "Delete" key) into unintended
       // parts of jupyter lab.
       this.node.focus();
+    }else if(event.type === 'blur'){
+      // Unselect any selected nodes when the editor loses focus
+      const deactivate = x => x.setSelected(false);
+      const model = this.diagramEngine.getModel();
+      model.getNodes().forEach(deactivate);
+      model.getLinks().forEach(deactivate);
     }
   }
 
   protected onAfterAttach(msg) {
     this.node.addEventListener('mouseup', this, true);
+    this.node.addEventListener('blur', this, true);
   }
 
   protected onBeforeDetach() {
     this.node.removeEventListener('mouseup', this, true);
+    this.node.removeEventListener('blur', this, true);
   }
 
   customDeserializeModel = (modelContext: any, diagramEngine: SRD.DiagramEngine) => {

--- a/src/xpipeWidget.tsx
+++ b/src/xpipeWidget.tsx
@@ -161,6 +161,22 @@ export class XPipePanel extends ReactWidget {
     });
   }
 
+  handleEvent(event: Event): void {
+    if(event.type === 'mouseup'){
+      // force focus on the editor in order stop key event propagation (e.g. "Delete" key) into unintended
+      // parts of jupyter lab.
+      this.node.focus();
+    }
+  }
+
+  protected onAfterAttach(msg) {
+    this.node.addEventListener('mouseup', this, true);
+  }
+
+  protected onBeforeDetach() {
+    this.node.removeEventListener('mouseup', this, true);
+  }
+
   customDeserializeModel = (modelContext: any, diagramEngine: SRD.DiagramEngine) => {
 
     let tempModel = new SRD.DiagramModel();


### PR DESCRIPTION
When a user clicks on a File in Jupyter Lab and then wants to delete a node, it would result in Jupyter Lab also wanting to delete that particular file. 

With this change, a click on the xpipes editor will result in the focus being moved back to the editor, so the delete key will not trigger the delete command on the file browser.