### PR TITLE
Use absolute path when compiling an xpipes file

### DIFF
--- a/xpipes/handlers/compile.py
+++ b/xpipes/handlers/compile.py
@@ -9,6 +9,7 @@ class CompileFileRouteHandler(APIHandler):
     def __get_notebook_absolute_path__(self, path):
         return Path(self.application.settings['server_root_dir']) / path
 
+    @tornado.web.authenticated
     def get(self):
         self.finish(json.dumps({"data": "This is file/generate endpoint!"}))
 

--- a/xpipes/handlers/compile.py
+++ b/xpipes/handlers/compile.py
@@ -3,9 +3,12 @@ import json
 import tornado
 from jupyter_server.base.handlers import APIHandler
 
+from pathlib import Path
 
 class CompileFileRouteHandler(APIHandler):
-    @tornado.web.authenticated
+    def __get_notebook_absolute_path__(self, path):
+        return Path(self.application.settings['server_root_dir']) / path
+
     def get(self):
         self.finish(json.dumps({"data": "This is file/generate endpoint!"}))
 
@@ -18,7 +21,7 @@ class CompileFileRouteHandler(APIHandler):
         except:
             python_script = ""
 
-        f = open(input_data["currentPath"], "w")
+        f = open(self.__get_notebook_absolute_path__(input_data["currentPath"]), "w")
         f.write(python_script)
         f.close()
         data = {"message": "completed"}

--- a/xpipes/handlers/compile.py
+++ b/xpipes/handlers/compile.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 class CompileFileRouteHandler(APIHandler):
     def __get_notebook_absolute_path__(self, path):
-        return (Path(self.application.settings['server_root_dir']) / path).resolve()
+        return (Path(self.application.settings['server_root_dir']) / path).expanduser().resolve()
 
     @tornado.web.authenticated
     def get(self):

--- a/xpipes/handlers/compile.py
+++ b/xpipes/handlers/compile.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 class CompileFileRouteHandler(APIHandler):
     def __get_notebook_absolute_path__(self, path):
-        return Path(self.application.settings['server_root_dir']) / path
+        return (Path(self.application.settings['server_root_dir']) / path).resolve()
 
     @tornado.web.authenticated
     def get(self):


### PR DESCRIPTION
# Description

When jupyter lab is running with a `--notebook-dir` that is different from its starting directory, compiling a file will result in a `File not found` exception. 

This it uses a relative file path which is resolved relatively to the current working directory. 

This PR changes this behavior to make it resolve the path relative to the `server_root_dir`, which points to the absolute directory for the `--notebook-dir` (or `--ServerApp.root_dir`) parameter.

## Pull Request Type

- [x] Xpipes Core (Jupyterlab Related changes)
- [ ] Xpipes Canvas (Custom RD Related changes)
- [ ] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Ensure it solves the actual problem

    1. Start jupyter lab with `--notebook-dir=examples`
    2. Create new xpipes file
    3. Add and connect HelloComponent
    4. Save + Compile + Run it
    5. See the output of the running script


2. Ensure it didn't break previously working behavior

    * Follow the same steps as in previous test, but start without `--notebook-dir` parameter.


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
