### PR TITLE
Use Config that comes in xai_components folder

### DIFF
--- a/xpipes/handlers/config.py
+++ b/xpipes/handlers/config.py
@@ -9,7 +9,7 @@ from configparser import ConfigParser
 def get_config():
     config = ConfigParser()
     config.read([
-        os.path.join(os.path.dirname(__file__), "..", "..", ".xpipes", "config.ini"),
+        os.path.join(os.path.dirname(__file__), "..", "..", "xai_components", ".xpipes", "config.ini"),
         os.path.expanduser("~/.xpipes/config.ini"),
         ".xpipes/config.ini"])
     return config


### PR DESCRIPTION
# Description

Due to the way wheels are installed, we need to use the config.ini inside the `xai_components` library.


## Pull Request Type

- [x] Xpipes Core (Jupyterlab Related changes)
- [ ] Xpipes Canvas (Custom RD Related changes)
- [ ] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Install xpipes from a wheel

    1. Start jupyter lab
    2. Check that component list is showing up


## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu (Konsole)
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
