### PR TITLE
Deduplicate Components

### DIFF
--- a/xpipes/handlers/components.py
+++ b/xpipes/handlers/components.py
@@ -103,6 +103,8 @@ class ComponentsRouteHandler(APIHandler):
                     components.extend(chain.from_iterable(self.extract_components(f, directory) for f in python_files))
 
 
+        components = list({(c["header"], c["task"]): c for c in components}.values())
+
         # Set up component colors according to palette
         for idx, c in enumerate(components):
             if c.get("color") is None:


### PR DESCRIPTION
# Description

As the component parser now looks into multiple directories, it is possible to have component duplication.

This solves the issue by only using the latest one it finds based on the header and component name.

## Pull Request Type

- [x] Xpipes Core (Jupyterlab Related changes)
- [ ] Xpipes Canvas (Custom RD Related changes)
- [ ] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Have duplicate components

    1. Copy xai_components to examples folder
    2. cd examples
    3. jupyter lab
    4. Check that only one set of components exists
    5. Change HelloComponent in examples folder to have `color="green"`
    6. Refresh component list and HelloComponent should be green now


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  