### PR TITLE
Add linux handler for start_xpipes.py

### DIFF
--- a/xpipes/start_xpipes.py
+++ b/xpipes/start_xpipes.py
@@ -26,7 +26,7 @@ def start_xpipes():
     
     # the current handler assumes that the user uses venv to install xpipes
     
-    lif platform == "win32":
+    if platform == "win32":
         xai_component_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components"
         config_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components" / ".xpipes"
     

--- a/xpipes/start_xpipes.py
+++ b/xpipes/start_xpipes.py
@@ -6,7 +6,7 @@ import sys
 import shutil
 import os
 from pathlib import Path
-
+from sys import platform
 
 def start_xpipes():
     print(
@@ -23,9 +23,19 @@ def start_xpipes():
 ================================
 '''
     )
-
-    xai_component_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components"
-    config_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components" / ".xpipes"
+    
+    # the current handler assumes that the user uses venv to install xpipes
+    
+    lif platform == "win32":
+        xai_component_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components"
+        config_path = Path(sys.executable).parents[1] / "Lib" / "site-packages" / "xai_components" / ".xpipes"
+    
+    else:  
+        # the dir path for linux venv looks like : venv/lib/python3.9/site-packages/xpipes
+        venv_python_version = os.listdir("venv/lib")[0]
+        xai_component_path = Path(sys.executable).parents[1] / "lib" / venv_python_version / "site-packages" / "xai_components"
+        config_path = Path(sys.executable).parents[1] / "lib" / venv_python_version / "site-packages" / "xai_components" / ".xpipes"
+        
     current_path = Path(os.getcwd()) / "xai_components"
     current_config_path = Path(os.getcwd()) / ".xpipes"
 


### PR DESCRIPTION
# Description

Was testing out the wheel creation process, was pleased to find that the Xpipes wheel build and usage is still robust in Windows, where the user simply needs to `pip install xpipes.whl` and run `xpipes`. `xpipes` will copy xai_components and .xpipes config to the current path, then launches jupyterlab.

In Linux running `xpipes` didn't work properly as the path was hardcoded to venv windows pathing. This pull request creates yet another hardcoded path handler for Linux.

## References
https://github.com/XpressAI/xpipes/pull/63

## Pull Request Type

- [x] Xpipes Core (Jupyterlab Related changes)
- [ ] Xpipes Canvas (Custom RD Related changes)
- [ ] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**Build Wheel**
Referring to the previous pull request, you would need to run:

```
Install build
py -m pip install --upgrade build
Run this command from the same directory where pyproject.toml is located.
py -m build
This command should output a lot of text and once completed should generate two files in the dist directory.
```
Verify that the wheel is created successfully. You may also want to test it in Windows / Linux


**Test Wheel**
1. Make a new dir, make a new venv, then pip install the generated .whl
2. run `xpipes`. You should be prompted to copy the xai_component folder and config
3. Jupyterlab will launch 

Verify that Xpipes features work well.

## Tested on?

- [x] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes
