### PR TITLE
Refactor components parser to remove hard-coded component types

### DIFF
--- a/xai_components/base.py
+++ b/xai_components/base.py
@@ -94,6 +94,7 @@ class BranchComponent(BaseComponent):
             return self.when_false
 
 
+@xai_component(type="if")
 class LoopComponent(Component):
     body: Component
 

--- a/xai_components/xai_learning/inference.py
+++ b/xai_components/xai_learning/inference.py
@@ -34,7 +34,7 @@ class LoadImage(Component):
         self.done = True
 
 
-@xai_component
+@xai_component(type="out")
 class ResizeImageData(Component):
     dataset: InArg[Tuple[np.array, np.array]]
     resized_dataset: OutArg[Tuple[np.array, np.array]]

--- a/xai_components/xai_learning/training.py
+++ b/xai_components/xai_learning/training.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from tqdm import tqdm
 
 
-@xai_component
+@xai_component(type="in")
 class ReadDataSet(Component):
     dataset_name: InArg[str]
     dataset: OutArg[Tuple[np.array, np.array]]
@@ -124,7 +124,7 @@ class ReadDataSet(Component):
 
         self.done = True
 
-@xai_component
+@xai_component(type="in")
 class ReadMaskDataSet(Component):
     dataset_name: InArg[str]
     mask_dataset_name: InArg[str]
@@ -173,7 +173,7 @@ class FlattenImageData(Component):
         self.done = True
 
 
-@xai_component
+@xai_component(type="split")
 class TrainTestSplit(Component):
     dataset: InArg[Tuple[np.array, np.array]]
     train_split: InArg[float]
@@ -211,7 +211,7 @@ class TrainTestSplit(Component):
         self.test.value = test
         self.done = True
 
-@xai_component
+@xai_component(type="model")
 class Create1DInputModel(Component):
     training_data: InArg[Tuple[np.array, np.array]]
 
@@ -242,7 +242,7 @@ class Create1DInputModel(Component):
 
         self.done = True
 
-@xai_component
+@xai_component(type="model")
 class Create2DInputModel(Component):
     training_data: InArg[Tuple[np.array, np.array]]
 
@@ -283,7 +283,7 @@ class Create2DInputModel(Component):
         self.done = True
 
 
-@xai_component
+@xai_component(type="train")
 class TrainImageClassifier(Component):
     training_data: InArg[Tuple[np.array, np.array]]
     training_epochs: InArg[int]
@@ -311,7 +311,7 @@ class TrainImageClassifier(Component):
         self.done = True
 
 
-@xai_component
+@xai_component(type="eval")
 class EvaluateAccuracy(Component):
     model: InArg[keras.Sequential]
     eval_dataset: InArg[Tuple[np.array, np.array]]
@@ -337,7 +337,7 @@ class EvaluateAccuracy(Component):
         self.done = True
 
 
-@xai_component
+@xai_component(type="enough")
 class ShouldStop(Component):
     target_accuracy: InArg[float]
     max_retries: InArg[int]
@@ -395,7 +395,7 @@ class SaveKerasModel(Component):
         self.done = True
 
 
-@xai_component
+@xai_component(type="convert")
 class SaveKerasModelInModelStash(Component):
     model: InArg[keras.Sequential]
     experiment_name: InArg[str]

--- a/xai_components/xai_pytorch/training.py
+++ b/xai_components/xai_pytorch/training.py
@@ -57,7 +57,7 @@ class ConvertTorchModelToOnnx(Component):
         self.done = True
     
 
-@xai_component
+@xai_component(type="model")
 class CreateUnetModel(Component):
     train_data: InArg[torch.utils.data.DataLoader]
     test_data: InArg[torch.utils.data.DataLoader]
@@ -110,7 +110,7 @@ class CreateUnetModel(Component):
         self.done = True
     
 
-@xai_component
+@xai_component(type="split")
 class ImageTrainTestSplit(Component):
     input_str: InArg[Tuple[str,str]]
     split_ratio: InArg[float]

--- a/xpipes/handlers/components.py
+++ b/xpipes/handlers/components.py
@@ -62,20 +62,6 @@ COLOR_PALETTE = [
 GROUP_GENERAL = "GENERAL"
 GROUP_ADVANCED = "ADVANCED"
 
-# TODO: attach this data to the actual model
-COMPONENT_OUTPUT_TYPE_MAPPING = {
-    "TrainTestSplit": "split",
-    "RotateCounterClockWiseComponent": "out",
-    "LoopComponent": "if",
-    "ReadDataSet": "in",
-    "ResizeImageData": "out",
-    "ShouldStop": "enough",
-    "SaveKerasModelInModelStash": "convert",
-    "EvaluateAccuracy": "eval",
-    "TrainImageClassifier": "train",
-    "CreateModel": "model"
-}
-
 class ComponentsRouteHandler(APIHandler):
     @tornado.web.authenticated
     def get(self):
@@ -148,14 +134,12 @@ class ComponentsRouteHandler(APIHandler):
             for v in node.body if is_arg(v)
         ]
 
-        output_type = COMPONENT_OUTPUT_TYPE_MAPPING.get(name) or "debug"
-
         output = {
             "path": file_path.as_posix(),
             "task": name,
             "header": GROUP_ADVANCED,
             "category": category,
-            "type": output_type,
+            "type": "debug",
             "variables": variables
         }
         output.update(keywords)


### PR DESCRIPTION

# Description

During the original refactoring of the component parser in https://github.com/XpressAI/xpipes/pull/72 a `TODO` item was left over:
Removing the hard-coded `type` for a fixed set of known components. 

The change introduced in https://github.com/XpressAI/xpipes/pull/81 now allows us to address this item in a very simple way: We can specify the type with the  `type` keyword in the `xai_decorator`.


## Pull Request Type

- [x] Xpipes Core (Jupyterlab Related changes)
- [ ] Xpipes Canvas (Custom RD Related changes)
- [x] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] Refactoring
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Manual check of `/xpipes/components/` output

    1. Open `http://localhost:8888/xpipes/components/`
    2. Check that the `type` on the affected components is still the same


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  