### PR TITLE
Handle Components outside the python path

### DIFF
--- a/src/components/xpipeBodyWidget.tsx
+++ b/src/components/xpipeBodyWidget.tsx
@@ -1391,9 +1391,7 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 	signalConnections.forEach(connectSignal);
 
 	const fetchComponentList = async () => {
-		const base_path = await getConfig("BASE_PATH");
-		const base_path_cfg = base_path["cfg"];
-		const response = await ComponentList(serviceManager, base_path_cfg);
+		const response = await ComponentList(serviceManager);
 
 		if (response.length > 0) {
 			setComponentList([]);

--- a/src/components_xpipe/Component.ts
+++ b/src/components_xpipe/Component.ts
@@ -7,7 +7,7 @@ async function get_all_components_method() {
     return components;
 }
 
-export default async function ComponentList(serviceManager: ServiceManager, basePath: string) {
+export default async function ComponentList(serviceManager: ServiceManager) {
     let component_list_result: string[] = await get_all_components_method();
     
     return component_list_result;

--- a/src/components_xpipe/Sidebar.tsx
+++ b/src/components_xpipe/Sidebar.tsx
@@ -138,12 +138,8 @@ export default function Sidebar(props: SidebarProps) {
     };
 
     const fetchComponentList = async () => {
-        // get the base path configuration 
-        const base_path = await getConfig("BASE_PATH");
-        const base_path_cfg = base_path["cfg"];
-
-        // get the component list by sending the jupyterlab frontend and base path
-        const response_1 = await ComponentList(props.lab.serviceManager, base_path_cfg);
+          // get the component list by sending the jupyterlab frontend and base path
+        const response_1 = await ComponentList(props.lab.serviceManager);
 
         // get the header from the components
         const response_2 = await fetchComponent(response_1);

--- a/xpipes/handlers/components.py
+++ b/xpipes/handlers/components.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pathlib
+import sys
 import ast
 from itertools import chain
 
@@ -86,10 +87,11 @@ class ComponentsRouteHandler(APIHandler):
                 "task": c["name"],
                 "header": GROUP_GENERAL,
                 "category": GROUP_GENERAL,
-                "path": "", # Default Components do not have a python-file backed implementation
                 "variables": [],
                 "type": c["returnType"]
             })
+
+        default_paths = set(pathlib.Path(p).expanduser().resolve() for p in sys.path)
 
         visited_directories = []
         for directory_string in self.get_component_directories():
@@ -100,7 +102,13 @@ class ComponentsRouteHandler(APIHandler):
                         and not any(pathlib.Path.samefile(directory, d) for d in visited_directories):
                     visited_directories.append(directory)
                     python_files = directory.rglob("xai_*/*.py")
-                    components.extend(chain.from_iterable(self.extract_components(f, directory) for f in python_files))
+
+                    python_path = directory.expanduser().resolve()
+
+                    if python_path.parent in default_paths:
+                        python_path = None
+
+                    components.extend(chain.from_iterable(self.extract_components(f, directory, python_path) for f in python_files))
 
 
         components = list({(c["header"], c["task"]): c for c in components}.values())
@@ -117,7 +125,7 @@ class ComponentsRouteHandler(APIHandler):
         paths.append(get_config().get("DEV", "BASE_PATH"))
         return paths
 
-    def extract_components(self, file_path, base_dir):
+    def extract_components(self, file_path, base_dir, python_path):
         parse_tree = ast.parse(file_path.read_text(), file_path)
         # Look for top level class definitions that are decorated with "@xai_component"
         is_xai_component = lambda node: isinstance(node, ast.ClassDef) and \
@@ -125,10 +133,10 @@ class ComponentsRouteHandler(APIHandler):
                                             (isinstance(decorator, ast.Name) and decorator.id == "xai_component")
                                             for decorator in node.decorator_list)
 
-        return [self.extract_component(node, file_path.relative_to(base_dir.parent))
+        return [self.extract_component(node, file_path.relative_to(base_dir), python_path)
                 for node in parse_tree.body if is_xai_component(node)]
 
-    def extract_component(self, node: ast.ClassDef, file_path):
+    def extract_component(self, node: ast.ClassDef, file_path, python_path):
         name = node.name
 
         keywords = {kw.arg: kw.value.value for kw in chain.from_iterable(decorator.keywords
@@ -153,7 +161,9 @@ class ComponentsRouteHandler(APIHandler):
         output_type = COMPONENT_OUTPUT_TYPE_MAPPING.get(name) or "debug"
 
         output = {
-            "path": file_path.as_posix(),
+            "class": name,
+            "package_name": ("xai_components." if python_path is None else "") + file_path.as_posix().replace("/", ".")[:-3],
+            "python_path": str(python_path) if python_path is not None else None,
             "task": name,
             "header": GROUP_ADVANCED,
             "category": category,


### PR DESCRIPTION
# Description
The changes in https://github.com/XpressAI/xpipes/pull/72 allow multiple paths to be scanned for components. 

These paths don't have to be on the regular python path. 

The default components are on the python path by virtue of being installed. 

But custom components aren't forced to be there. A user might for example keep their custom components in their home directory, or in ther working directory, or in any number of other places. 

The changes in this PR introduce support for actually accessing components in abitrary places. 

## Pull Request Type

- [X] Xpipes Core (Jupyterlab Related changes)
- [X] Xpipes Canvas (Custom RD Related changes)
- [ ] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Create new component and use it

    1. Start jupyter lab
    2. Create folder `xai_components/xai_example`
    3. In that folder, create `example.py` with the content below.
    4. Create new xpipes file
    5. Add Both HelloWorldComponent and HelloComponent to the canvas and connect everything from start to finish
    6. Save, Compile and Run to find the output from both components there. 

```python
from xai_components.base import InArg, OutArg, InCompArg, Component, xai_component

@xai_component(color="blue")
class HelloWorldComponent(Component):

    def __init__(self):

        self.done = False

    def execute(self) -> None:
        print("Hello, World!")

        self.done = True
```


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

