### PR TITLE
Update modelstash component library with Konsole handler + smarter UploadToModelStash 

### DIFF
--- a/examples/MSTrainUpload.xpipes
+++ b/examples/MSTrainUpload.xpipes
@@ -1,1715 +1,2050 @@
 {
-  "x": 10,
-  "y": 10,
-  "id": "ebf5b7de-7560-4a66-8124-0861ce62065c",
-  "offsetX": -599,
-  "offsetY": -49,
-  "zoom": 100,
-  "gridSize": 0,
-  "layers": [
-    {
-      "id": "24e9ee99-0dec-456a-9ffa-e3ac19deeb4e",
-      "type": "diagram-links",
-      "isSvg": true,
-      "transformed": true,
-      "models": {
-        "932683ce-2715-4e56-80ec-f5dc617d1715": {
-          "id": "932683ce-2715-4e56-80ec-f5dc617d1715",
-          "type": "default",
-          "source": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
-          "sourcePort": "ea0d5274-a264-4e83-be99-98dfd344b694",
-          "target": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-          "targetPort": "153f23c1-e13d-4de9-aaa2-e6f5076653c8",
-          "points": [
-            {
-              "id": "ed2f5dd2-6f8c-4b9f-b8f4-cc942c705196",
-              "type": "point",
-              "x": -138.59091186523438,
-              "y": 96.06818389892578
-            },
-            {
-              "id": "4939bc2a-727c-4a63-8122-59ba0a965f08",
-              "type": "point",
-              "x": -77.29547119140625,
-              "y": 163.4204559326172
+    "id": "ebf5b7de-7560-4a66-8124-0861ce62065c",
+    "offsetX": -478.00953492865665,
+    "offsetY": 52.54677710094448,
+    "zoom": 94.1666666666666,
+    "gridSize": 0,
+    "layers": [
+        {
+            "id": "24e9ee99-0dec-456a-9ffa-e3ac19deeb4e",
+            "type": "diagram-links",
+            "isSvg": true,
+            "transformed": true,
+            "models": {
+                "932683ce-2715-4e56-80ec-f5dc617d1715": {
+                    "id": "932683ce-2715-4e56-80ec-f5dc617d1715",
+                    "type": "default",
+                    "selected": false,
+                    "source": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
+                    "sourcePort": "ea0d5274-a264-4e83-be99-98dfd344b694",
+                    "target": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                    "targetPort": "153f23c1-e13d-4de9-aaa2-e6f5076653c8",
+                    "points": [
+                        {
+                            "id": "ed2f5dd2-6f8c-4b9f-b8f4-cc942c705196",
+                            "type": "point",
+                            "x": -238.6562184385949,
+                            "y": 164.49998297355464
+                        },
+                        {
+                            "id": "4939bc2a-727c-4a63-8122-59ba0a965f08",
+                            "type": "point",
+                            "x": -166.3281323282519,
+                            "y": 164.93749161570065
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "a070bc33-7106-4e2f-abdb-f517557b4d07": {
+                    "id": "a070bc33-7106-4e2f-abdb-f517557b4d07",
+                    "type": "default",
+                    "selected": false,
+                    "source": "bacd83a3-8d6e-4db5-ba21-bd3c25af184d",
+                    "sourcePort": "31173d23-e739-4784-8444-88e9ba6ba94e",
+                    "target": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "targetPort": "f79849fb-e090-49f1-837a-4f6d2db1c714",
+                    "points": [
+                        {
+                            "id": "97a3cd91-a819-4fd3-9a7d-4578b62507fc",
+                            "type": "point",
+                            "x": 56.06250131389427,
+                            "y": 259.26561877623726
+                        },
+                        {
+                            "id": "428315fa-52b4-4f85-b741-fe823a9848c0",
+                            "type": "point",
+                            "x": 104.2343741533578,
+                            "y": 196.1875024183832
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "d9fbe310-056f-4f2d-946a-db172d25a894": {
+                    "id": "d9fbe310-056f-4f2d-946a-db172d25a894",
+                    "type": "default",
+                    "selected": false,
+                    "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "sourcePort": "2ecffc71-058b-40a2-b51a-58226f6d3bf4",
+                    "target": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                    "targetPort": "31a9bc06-d8e9-4ffd-8b92-abc9a27ff36d",
+                    "points": [
+                        {
+                            "id": "16343326-1821-4404-8c2f-a914e84b4131",
+                            "type": "point",
+                            "x": 237.9062599560404,
+                            "y": 196.1875024183832
+                        },
+                        {
+                            "id": "7ecaa201-9f7d-4247-b489-253d993ca198",
+                            "type": "point",
+                            "selected": false,
+                            "x": 304.43850867444286,
+                            "y": 194.5564455679066
+                        },
+                        {
+                            "id": "ae5e7904-edec-46e3-81fd-c27a043c0698",
+                            "type": "point",
+                            "selected": false,
+                            "x": 307.83656807991315,
+                            "y": 298.89914933627017
+                        },
+                        {
+                            "id": "1867beca-fecd-414a-9630-fabe76f79895",
+                            "type": "point",
+                            "x": 883.6250056349679,
+                            "y": 299.8437351340912
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "e14d15f1-130e-4ea9-977f-7cb96acff519": {
+                    "id": "e14d15f1-130e-4ea9-977f-7cb96acff519",
+                    "type": "default",
+                    "selected": false,
+                    "source": "37e8b213-8bc0-402e-9ba5-0fc02c5fd6af",
+                    "sourcePort": "5b11bf77-5061-4aab-879e-d7631cd4b698",
+                    "target": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                    "targetPort": "5a6118b8-8e56-41af-96df-68c810da016e",
+                    "points": [
+                        {
+                            "id": "2f1844e2-07f3-4add-b8fa-9c0aadb0b1ce",
+                            "type": "point",
+                            "x": -237.84374868610595,
+                            "y": 243.15625889999274
+                        },
+                        {
+                            "id": "f50f15e3-d90f-4038-b8c9-d9c5aff26955",
+                            "type": "point",
+                            "x": -166.3281323282519,
+                            "y": 180.93747433140862
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "1e52f7d5-7d20-4869-9c70-bfda0910b079": {
+                    "id": "1e52f7d5-7d20-4869-9c70-bfda0910b079",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                    "sourcePort": "ee851724-cfc8-45a2-a037-eb43d7ae99bb",
+                    "target": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "targetPort": "421d308c-5017-43d5-afb5-ebb2fd63780e",
+                    "points": [
+                        {
+                            "id": "19d3e21b-b002-4e33-8adb-9b32d1f840c0",
+                            "type": "point",
+                            "x": 1485.3281133506762,
+                            "y": -6.625004333293508
+                        },
+                        {
+                            "id": "612e3aaf-48ab-44de-b762-938ef51a3b73",
+                            "type": "point",
+                            "x": 1615.8749883506764,
+                            "y": 157.3281468632117
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "49533ce1-56bb-4bc1-9b12-33aa93556e28": {
+                    "id": "49533ce1-56bb-4bc1-9b12-33aa93556e28",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "sourcePort": "64a8f308-7603-4690-ab7b-17a7aec98a99",
+                    "target": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
+                    "targetPort": "82ffb26d-208f-4c04-8b2c-c5342aae2641",
+                    "points": [
+                        {
+                            "id": "70e99f3b-7a1e-4da2-8030-4d3c860d5747",
+                            "type": "point",
+                            "x": 1823.5469238456985,
+                            "y": 157.3281468632117
+                        },
+                        {
+                            "id": "79da0a62-1e65-4207-b346-7e76e45bd572",
+                            "type": "point",
+                            "x": 1880.1250229192606,
+                            "y": 146.26562741838316
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "88e64805-f194-4860-86ff-1bf3e5c0ca69": {
+                    "id": "88e64805-f194-4860-86ff-1bf3e5c0ca69",
+                    "type": "default",
+                    "selected": false,
+                    "source": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                    "sourcePort": "ea4a4199-3c8e-435e-a9b4-eb6cc6962e5d",
+                    "target": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "targetPort": "0f2a751c-0b91-48d4-9c02-e30ccf7418aa",
+                    "points": [
+                        {
+                            "id": "7495c09d-2995-4e40-9ab6-ad9fbf6eb39e",
+                            "type": "point",
+                            "x": 1026.468790203552,
+                            "y": 283.84375241838325
+                        },
+                        {
+                            "id": "6e4ab204-597f-4f06-82d4-cec93fe0b313",
+                            "type": "point",
+                            "x": 1615.8749883506764,
+                            "y": 301.32812093677376
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "d393f884-ff0a-4c5f-b42c-2caa8705d368": {
+                    "id": "d393f884-ff0a-4c5f-b42c-2caa8705d368",
+                    "type": "default",
+                    "selected": false,
+                    "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "sourcePort": "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
+                    "target": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "targetPort": "f01b7d9b-5fcb-4b2a-b31d-587fee7e6c43",
+                    "points": [
+                        {
+                            "id": "7f316f6e-a860-4e80-9202-5dff00548652",
+                            "type": "point",
+                            "x": 237.9062599560404,
+                            "y": 180.18748729462766
+                        },
+                        {
+                            "id": "2c760975-9d6a-4bc0-9a50-68aba28965ae",
+                            "type": "point",
+                            "x": 554.7187772403327,
+                            "y": 180.46872433140862
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "c5befaa5-6e8a-4893-8636-db220d818ced": {
+                    "id": "c5befaa5-6e8a-4893-8636-db220d818ced",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "sourcePort": "7f6cb3f3-bcb4-4c00-9efe-00a198f73297",
+                    "target": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                    "targetPort": "b76cfe91-1abc-468a-80a2-a461305f7d03",
+                    "points": [
+                        {
+                            "id": "ad7b155d-ac69-4662-8b27-dad66d98a5f4",
+                            "type": "point",
+                            "x": 755.0312988456978,
+                            "y": 148.46875889999268
+                        },
+                        {
+                            "id": "97ba1c4c-c296-44f6-b154-453105de15ce",
+                            "type": "point",
+                            "selected": false,
+                            "x": 827.0620468223437,
+                            "y": 149.7410261542231
+                        },
+                        {
+                            "id": "e634155e-ae3b-4f35-8ec2-20f282ac27e1",
+                            "type": "point",
+                            "selected": false,
+                            "x": 831.2725731381332,
+                            "y": 268.33751738229324
+                        },
+                        {
+                            "id": "b6121010-9dee-4d6c-a520-ac47e66df67d",
+                            "type": "point",
+                            "x": 883.6250056349679,
+                            "y": 267.8437372946277
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "db28b105-7adf-4a58-aa23-292081aa5eb5": {
+                    "id": "db28b105-7adf-4a58-aa23-292081aa5eb5",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "sourcePort": "6efa391f-2e0d-4433-8c6d-2062a1089d20",
+                    "target": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                    "targetPort": "2a9c1595-da2c-4a7f-a392-4cd03094b5e2",
+                    "points": [
+                        {
+                            "id": "34bba3eb-12cf-48cf-a40a-1b5f07f8e038",
+                            "type": "point",
+                            "x": 755.0312988456978,
+                            "y": 164.46874161570065
+                        },
+                        {
+                            "id": "c737b824-6453-4c62-b9a5-79fde41b7ee5",
+                            "type": "point",
+                            "selected": false,
+                            "x": 805.3076608574315,
+                            "y": 167.28488580334587
+                        },
+                        {
+                            "id": "3ac72e55-9ce8-4c4f-903a-7965b2f63e1b",
+                            "type": "point",
+                            "selected": false,
+                            "x": 811.6234503311157,
+                            "y": 282.3726051015915
+                        },
+                        {
+                            "id": "b52b49a3-dadb-4278-a253-ce26660d59d8",
+                            "type": "point",
+                            "x": 883.6250056349679,
+                            "y": 283.84375241838325
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "93118dc6-8af1-4c2e-b605-86081adf153d": {
+                    "id": "93118dc6-8af1-4c2e-b605-86081adf153d",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "sourcePort": "a50cc20a-1604-495d-a6d3-2c6d9e3d9b49",
+                    "target": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "targetPort": "4808e175-eeb0-49e9-92a6-50f8820effa8",
+                    "points": [
+                        {
+                            "id": "16ffb46d-056b-43d4-bdc7-5a75a86f6028",
+                            "type": "point",
+                            "x": 755.0312988456978,
+                            "y": 180.46872433140862
+                        },
+                        {
+                            "id": "ebd14527-e6c9-419f-98fe-4a7c433b1693",
+                            "type": "point",
+                            "selected": false,
+                            "x": 791.5062396739413,
+                            "y": 180.48308817091524
+                        },
+                        {
+                            "id": "8a92bee1-06b4-4ec4-83ef-4c743af85ee4",
+                            "type": "point",
+                            "selected": false,
+                            "x": 795.4830994539227,
+                            "y": 327.2848858033459
+                        },
+                        {
+                            "id": "a2798807-bba7-4889-9d12-587aa38a4052",
+                            "type": "point",
+                            "selected": false,
+                            "x": 1545.658538050414,
+                            "y": 338.5129559787845
+                        },
+                        {
+                            "id": "891f5e4b-cd85-43a3-ae31-1319612440f2",
+                            "type": "point",
+                            "selected": false,
+                            "x": 1541.6351462375485,
+                            "y": 284.0568156279073
+                        },
+                        {
+                            "id": "a782b214-20b9-4267-809a-71b2fad7a47a",
+                            "type": "point",
+                            "x": 1615.8749883506764,
+                            "y": 285.3281382210658
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "c7f41f3d-c452-4536-bf10-3e88b9268549": {
+                    "id": "c7f41f3d-c452-4536-bf10-3e88b9268549",
+                    "type": "default",
+                    "selected": false,
+                    "source": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                    "sourcePort": "5a9ebcf7-d222-47ea-b931-37a877149a01",
+                    "target": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "targetPort": "578de5fc-7321-4a00-b953-2667cc47723a",
+                    "points": [
+                        {
+                            "id": "e232d75e-15e5-45c3-b2ff-24fbb41aca1c",
+                            "type": "point",
+                            "x": -15.51559775966773,
+                            "y": 164.93749161570065
+                        },
+                        {
+                            "id": "eeaf5184-1f5a-4753-8da0-ecd43e6d3b7b",
+                            "type": "point",
+                            "x": 104.2343741533578,
+                            "y": 164.1875045789197
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "3b25646a-6c87-4ebd-8413-c35b00abb182": {
+                    "id": "3b25646a-6c87-4ebd-8413-c35b00abb182",
+                    "type": "default",
+                    "selected": false,
+                    "source": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                    "sourcePort": "d396e843-1995-40ed-a2d3-84d0ab687d0f",
+                    "target": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "targetPort": "ca05f0cb-1c2b-4ea4-b07c-e0656aa5d7f5",
+                    "points": [
+                        {
+                            "id": "45c01abb-3e68-442b-a207-d2f3b0aa151d",
+                            "type": "point",
+                            "x": -15.51559775966773,
+                            "y": 180.93747433140862
+                        },
+                        {
+                            "id": "d8d96134-ddef-4269-af3a-704652a137f9",
+                            "type": "point",
+                            "x": 104.2343741533578,
+                            "y": 180.18748729462766
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "77a86d2e-9257-46a1-9ff0-915fd8fc5300": {
+                    "id": "77a86d2e-9257-46a1-9ff0-915fd8fc5300",
+                    "type": "default",
+                    "selected": false,
+                    "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "sourcePort": "465eb792-f0ad-4e11-b459-cec362c7c8c4",
+                    "target": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                    "targetPort": "37665a60-944d-444b-86a8-3e5be6853cf4",
+                    "points": [
+                        {
+                            "id": "acdde564-f654-4b4a-bd51-a59d93aa68e6",
+                            "type": "point",
+                            "x": 237.9062599560404,
+                            "y": 164.1875045789197
+                        },
+                        {
+                            "id": "81993ee7-4c28-4c29-9109-42cfcaec4f58",
+                            "type": "point",
+                            "selected": false,
+                            "x": 258.863522240714,
+                            "y": 165.2516531514806
+                        },
+                        {
+                            "id": "fb06357e-ee7f-4bff-88aa-354e064f10b9",
+                            "type": "point",
+                            "selected": false,
+                            "x": 255.76674804716566,
+                            "y": 40.606491861158084
+                        },
+                        {
+                            "id": "ec971b23-3e98-4593-9212-e4956421ba5a",
+                            "type": "point",
+                            "x": 297.3594065614055,
+                            "y": 41.734377418383104
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "805e5008-571e-405a-bfce-b2ce7fbc9a83": {
+                    "id": "805e5008-571e-405a-bfce-b2ce7fbc9a83",
+                    "type": "default",
+                    "selected": false,
+                    "source": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                    "sourcePort": "da2a84c2-aaba-4594-9704-ca68ddcf83f1",
+                    "target": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "targetPort": "230fa965-f9fb-4faf-a48f-e39fb229b428",
+                    "points": [
+                        {
+                            "id": "7fc19dfa-ef67-4a7b-acbb-3a86baf78e74",
+                            "type": "point",
+                            "x": 471.4062750797961,
+                            "y": 41.734377418383104
+                        },
+                        {
+                            "id": "28271ce9-53c4-4136-abb9-fa288d959028",
+                            "type": "point",
+                            "selected": false,
+                            "x": 510.8491853231512,
+                            "y": 41.65923123647809
+                        },
+                        {
+                            "id": "158bd2a5-2b7e-45e5-b9c9-f4fb8515e545",
+                            "type": "point",
+                            "selected": false,
+                            "x": 510.4764254665203,
+                            "y": 147.44520153857738
+                        },
+                        {
+                            "id": "e7e1bc95-b817-4941-be2f-8da6ef52e10b",
+                            "type": "point",
+                            "x": 554.7187772403327,
+                            "y": 148.46875889999268
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "9f1bd30c-0146-4bf9-bcbb-83a96ae1d6a7": {
+                    "id": "9f1bd30c-0146-4bf9-bcbb-83a96ae1d6a7",
+                    "type": "default",
+                    "selected": false,
+                    "source": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                    "sourcePort": "11197882-2a08-4602-a9d8-db67bb986ec0",
+                    "target": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "targetPort": "820ae49a-2d6a-4a68-b309-04ef3838c719",
+                    "points": [
+                        {
+                            "id": "73a9e76d-7381-45b2-8e82-57694b0476ae",
+                            "type": "point",
+                            "x": 471.4062750797961,
+                            "y": 57.73437633811486
+                        },
+                        {
+                            "id": "e9c6c4e7-ce9e-413d-86bd-166db3972c8f",
+                            "type": "point",
+                            "selected": false,
+                            "x": 494.7140086718455,
+                            "y": 57.70019385808587
+                        },
+                        {
+                            "id": "158a36c2-60cd-4bf8-add9-a211766a1be2",
+                            "type": "point",
+                            "selected": false,
+                            "x": 496.5409415955526,
+                            "y": 166.0258466998677
+                        },
+                        {
+                            "id": "9e77cbf4-5efe-4cb4-9dbe-93a530c9e6a4",
+                            "type": "point",
+                            "x": 554.7187772403327,
+                            "y": 164.46874161570065
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "5468df02-a360-45ce-89a5-822bd2b7c5e3": {
+                    "id": "5468df02-a360-45ce-89a5-822bd2b7c5e3",
+                    "type": "default",
+                    "selected": false,
+                    "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "sourcePort": "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
+                    "target": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                    "targetPort": "d6b63430-fb78-4985-be1e-7b13940220b5",
+                    "points": [
+                        {
+                            "id": "f788bad2-9fcf-4509-a6ea-e40d0717d344",
+                            "type": "point",
+                            "x": 237.9062599560404,
+                            "y": 180.18748729462766
+                        },
+                        {
+                            "id": "ac5ab122-7e68-4329-9c6c-f1cde18da22e",
+                            "type": "point",
+                            "selected": false,
+                            "x": 280.54094159555274,
+                            "y": 180.7355241192225
+                        },
+                        {
+                            "id": "85bcfc38-a5bf-4d90-90a1-f165c2e1fdb7",
+                            "type": "point",
+                            "selected": false,
+                            "x": 275.121586756843,
+                            "y": 56.86455637728711
+                        },
+                        {
+                            "id": "fd5eaa35-9c1f-4311-9347-2fb3fbf32f63",
+                            "type": "point",
+                            "x": 297.3594065614055,
+                            "y": 57.73437633811486
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "d4e9857d-c809-44f9-a2a4-27b55e250e0f": {
+                    "id": "d4e9857d-c809-44f9-a2a4-27b55e250e0f",
+                    "type": "default",
+                    "selected": false,
+                    "source": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                    "sourcePort": "0f5d33b4-c364-4788-b4c8-0fe51ccc7ffb",
+                    "target": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "targetPort": "7744917f-3014-4c2d-9188-68a2e5406f9b",
+                    "points": [
+                        {
+                            "id": "08b55d5c-ef41-4dcf-bd70-e674935401a9",
+                            "type": "point",
+                            "x": 471.4062750797961,
+                            "y": 73.73437525784664
+                        },
+                        {
+                            "id": "48dbac2b-54b5-4d0b-b27e-a97cf5bc48d7",
+                            "type": "point",
+                            "selected": false,
+                            "x": 1526.0058372312258,
+                            "y": 89.91199470745785
+                        },
+                        {
+                            "id": "bc3fe83c-58c3-493e-b667-7eebbc09ec55",
+                            "type": "point",
+                            "selected": false,
+                            "x": 1539.5766667053845,
+                            "y": 265.48371621270263
+                        },
+                        {
+                            "id": "62760de6-cde1-480d-9851-d509b0b30992",
+                            "type": "point",
+                            "x": 1615.8749883506764,
+                            "y": 269.32812309731025
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "572afe99-7175-4293-913d-0307ff21b853": {
+                    "id": "572afe99-7175-4293-913d-0307ff21b853",
+                    "type": "default",
+                    "selected": false,
+                    "source": "fbdc1fc8-570e-4b4e-b122-6b202a6ebe3d",
+                    "sourcePort": "9555acbb-01fa-480d-8d3f-c7f7e9c17d74",
+                    "target": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "targetPort": "0d5a596a-495c-4ec9-8cdd-0ffd58267db2",
+                    "points": [
+                        {
+                            "id": "5f339388-56a1-454a-bd69-3b2ca0e42de4",
+                            "type": "point",
+                            "x": 511.51562523362634,
+                            "y": 260.90624377623726
+                        },
+                        {
+                            "id": "6ef4798c-e2f2-4b62-9eae-556f491258d9",
+                            "type": "point",
+                            "x": 554.7187772403327,
+                            "y": 196.46877186321174
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "5d844560-594a-40a4-9a39-424a6916035a": {
+                    "id": "5d844560-594a-40a4-9a39-424a6916035a",
+                    "type": "default",
+                    "selected": false,
+                    "source": "4258629c-6599-4954-8cfd-ff91068f3d83",
+                    "sourcePort": "ff7a7f01-4708-45de-b14f-c6ec5946b5af",
+                    "target": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                    "targetPort": "44b9fb0f-4567-42ab-9050-4a3337544c75",
+                    "points": [
+                        {
+                            "id": "c9d9b6ef-be07-4028-984e-b76d84fe206c",
+                            "type": "point",
+                            "x": 1233.234337424238,
+                            "y": -6.249998661885185
+                        },
+                        {
+                            "id": "ab1f22e8-e71f-45af-8577-5a41fbccf5ab",
+                            "type": "point",
+                            "x": 1343.5781652035523,
+                            "y": 25.374989455164062
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "007d20a2-ad0b-4fa7-acf7-19e6bb25846f": {
+                    "id": "007d20a2-ad0b-4fa7-acf7-19e6bb25846f",
+                    "type": "default",
+                    "selected": false,
+                    "source": "b4cecdb7-d266-495e-bbc4-4831389f05d4",
+                    "sourcePort": "0700928f-18eb-43a3-9b53-9f7dbedde041",
+                    "target": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                    "targetPort": "2ea24055-2021-4334-b17f-bfc971e52a15",
+                    "points": [
+                        {
+                            "id": "77ab3c7b-8e7d-40c9-9848-a1873563a018",
+                            "type": "point",
+                            "x": 1236.640552855654,
+                            "y": 46.296879578919615
+                        },
+                        {
+                            "id": "96caa835-392e-4a03-a6b9-086879ac9218",
+                            "type": "point",
+                            "x": 1343.5781652035523,
+                            "y": 41.37500457891961
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "557e7902-fa58-4a31-bedb-cda730cf5e39": {
+                    "id": "557e7902-fa58-4a31-bedb-cda730cf5e39",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "sourcePort": "7f6cb3f3-bcb4-4c00-9efe-00a198f73297",
+                    "target": null,
+                    "targetPort": null,
+                    "points": [
+                        {
+                            "id": "dcb1f128-6562-49ca-ab6e-a208a9bc75f5",
+                            "type": "point",
+                            "x": 755.0312988456978,
+                            "y": 148.46875889999268
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "6c4323fb-e6bb-4587-9dc9-448a9319779c": {
+                    "id": "6c4323fb-e6bb-4587-9dc9-448a9319779c",
+                    "type": "default",
+                    "selected": false,
+                    "source": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                    "sourcePort": "339e8673-50f8-4b4b-87c9-4dc76cef6f51",
+                    "target": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                    "targetPort": "29fc940f-24b5-4959-83de-e4f79f962f7f",
+                    "points": [
+                        {
+                            "id": "cc1702ac-0c50-48d7-9296-fbff5d7b6ec5",
+                            "type": "point",
+                            "x": 1026.468790203552,
+                            "y": 267.8437372946277
+                        },
+                        {
+                            "id": "a87b9266-2d42-4b5b-bb4c-cc392907ac5e",
+                            "type": "point",
+                            "x": 1092.843712424238,
+                            "y": 153.76562741838316
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "e19b5428-9db2-4962-9d13-bc989246064c": {
+                    "id": "e19b5428-9db2-4962-9d13-bc989246064c",
+                    "type": "default",
+                    "selected": false,
+                    "source": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "sourcePort": "6efa391f-2e0d-4433-8c6d-2062a1089d20",
+                    "target": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                    "targetPort": "67a69254-fb78-4af0-af88-94c3b46c0501",
+                    "points": [
+                        {
+                            "id": "92d50aee-b7e4-4d23-9511-e6d586f17a0b",
+                            "type": "point",
+                            "x": 755.0312988456978,
+                            "y": 164.46874161570065
+                        },
+                        {
+                            "id": "37bc19c6-901b-41c9-9637-2720c2a5571b",
+                            "type": "point",
+                            "x": 1092.843712424238,
+                            "y": 169.7656425421387
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "0f9a8920-fb8a-4c8f-88b0-f5d6d2892398": {
+                    "id": "0f9a8920-fb8a-4c8f-88b0-f5d6d2892398",
+                    "type": "default",
+                    "selected": false,
+                    "source": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                    "sourcePort": "283a0cb1-0c4c-43df-adc0-4ef0210f030d",
+                    "target": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "targetPort": "d7fb88f9-32d8-440f-a2c9-6e658ae8f9b7",
+                    "points": [
+                        {
+                            "id": "e7d305d3-1d34-4ea5-8431-c793051e7416",
+                            "type": "point",
+                            "x": 1277.281281561406,
+                            "y": 169.7656425421387
+                        },
+                        {
+                            "id": "30541b42-77cc-4ac6-8e1d-a2f460bfc17a",
+                            "type": "point",
+                            "x": 1615.8749883506764,
+                            "y": 173.3281295789197
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "96e6b9e8-3fa6-4f14-a9d9-7c2e9549e252": {
+                    "id": "96e6b9e8-3fa6-4f14-a9d9-7c2e9549e252",
+                    "type": "default",
+                    "selected": false,
+                    "source": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                    "sourcePort": "3c0bc86a-1294-4f3a-b594-eaf15cfa8736",
+                    "target": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                    "targetPort": "d8808a3f-aba3-43e4-9b1f-d0845bac1e24",
+                    "points": [
+                        {
+                            "id": "884931c1-201e-4546-989b-31a1c99df6db",
+                            "type": "point",
+                            "x": 1277.281281561406,
+                            "y": 153.76562741838316
+                        },
+                        {
+                            "id": "1f4b61b8-7738-4202-83aa-95d6c3cf8d85",
+                            "type": "point",
+                            "x": 1343.5781652035523,
+                            "y": -6.625004333293508
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                }
             }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
         },
-        "1dbe308f-36de-4235-93e5-a5b8abebb169": {
-          "id": "1dbe308f-36de-4235-93e5-a5b8abebb169",
-          "type": "default",
-          "source": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "sourcePort": "5ff15ca1-ac79-4dbd-ad5a-3b614ea5306a",
-          "target": "b63890eb-b632-4c80-9254-2d010a4322b6",
-          "targetPort": "b76cfe91-1abc-468a-80a2-a461305f7d03",
-          "points": [
-            {
-              "id": "f13fbdbe-4bbd-4bd5-bef6-20ee01444cc8",
-              "type": "point",
-              "x": 736.8977355957031,
-              "y": 167.0454559326172
-            },
-            {
-              "id": "53eaf0c7-a0b3-48cb-8a0c-a1874cca084e",
-              "type": "point",
-              "x": 790.32958984375,
-              "y": 168.0341033935547
+        {
+            "id": "38a1e357-4abe-4755-944f-cdcadba9c59f",
+            "type": "diagram-nodes",
+            "isSvg": false,
+            "transformed": true,
+            "models": {
+                "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8": {
+                    "id": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "Start"
+                    },
+                    "x": -277.36387906511334,
+                    "y": 129.86342894694232,
+                    "ports": [
+                        {
+                            "id": "ea0d5274-a264-4e83-be99-98dfd344b694",
+                            "type": "default",
+                            "x": -246.1562184385949,
+                            "y": 156.99998297355464,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
+                            "links": [
+                                "932683ce-2715-4e56-80ec-f5dc617d1715"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "1f742844-3d9b-4818-a7c3-4daba263ff78",
+                            "type": "default",
+                            "x": -246.1562184385949,
+                            "y": 172.99999809731017,
+                            "name": "parameter-out-1",
+                            "alignment": "right",
+                            "parentNode": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
+                            "links": [],
+                            "in": false,
+                            "label": "  "
+                        }
+                    ],
+                    "name": "Start",
+                    "color": "rgb(255,102,102)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "ea0d5274-a264-4e83-be99-98dfd344b694",
+                        "1f742844-3d9b-4818-a7c3-4daba263ff78"
+                    ]
+                },
+                "b9e041cf-27c7-4488-ada4-6623adb0ab30": {
+                    "id": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "Finish",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 1870.6331149610653,
+                    "y": 111.64004365480884,
+                    "ports": [
+                        {
+                            "id": "82ffb26d-208f-4c04-8b2c-c5342aae2641",
+                            "type": "default",
+                            "x": 1872.6250229192606,
+                            "y": 138.76562741838316,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
+                            "links": [
+                                "49533ce1-56bb-4bc1-9b12-33aa93556e28"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "e8a1caeb-514f-4d71-8afa-77d5cf4dac5e",
+                            "type": "default",
+                            "x": 1872.6250229192606,
+                            "y": 154.7656425421387,
+                            "name": "parameter-in-1",
+                            "alignment": "left",
+                            "parentNode": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
+                            "links": [],
+                            "in": true,
+                            "label": "  "
+                        }
+                    ],
+                    "name": "Finish",
+                    "color": "rgb(255,102,102)",
+                    "portsInOrder": [
+                        "82ffb26d-208f-4c04-8b2c-c5342aae2641",
+                        "e8a1caeb-514f-4d71-8afa-77d5cf4dac5e"
+                    ],
+                    "portsOutOrder": []
+                },
+                "d0d51a3e-7356-4237-8dbc-65d0f395b2fd": {
+                    "id": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "in",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": -175.8289505734335,
+                    "y": 130.30915190583252,
+                    "ports": [
+                        {
+                            "id": "153f23c1-e13d-4de9-aaa2-e6f5076653c8",
+                            "type": "default",
+                            "x": -173.8281323282519,
+                            "y": 157.43749161570065,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                            "links": [
+                                "932683ce-2715-4e56-80ec-f5dc617d1715"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "5a6118b8-8e56-41af-96df-68c810da016e",
+                            "type": "default",
+                            "x": -173.8281323282519,
+                            "y": 173.43747433140862,
+                            "name": "parameter-string-in-1",
+                            "alignment": "left",
+                            "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                            "links": [
+                                "e14d15f1-130e-4ea9-977f-7cb96acff519"
+                            ],
+                            "in": true,
+                            "label": "dataset_name"
+                        },
+                        {
+                            "id": "5a9ebcf7-d222-47ea-b931-37a877149a01",
+                            "type": "default",
+                            "x": -23.015597759667735,
+                            "y": 157.43749161570065,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                            "links": [
+                                "c7f41f3d-c452-4536-bf10-3e88b9268549"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "d396e843-1995-40ed-a2d3-84d0ab687d0f",
+                            "type": "default",
+                            "x": -23.015597759667735,
+                            "y": 173.43747433140862,
+                            "name": "out-1",
+                            "alignment": "right",
+                            "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
+                            "links": [
+                                "3b25646a-6c87-4ebd-8413-c35b00abb182"
+                            ],
+                            "in": false,
+                            "label": "dataset"
+                        }
+                    ],
+                    "name": "ReadDataSet",
+                    "color": "rgb(255,102,102)",
+                    "portsInOrder": [
+                        "153f23c1-e13d-4de9-aaa2-e6f5076653c8",
+                        "5a6118b8-8e56-41af-96df-68c810da016e"
+                    ],
+                    "portsOutOrder": [
+                        "5a9ebcf7-d222-47ea-b931-37a877149a01",
+                        "d396e843-1995-40ed-a2d3-84d0ab687d0f"
+                    ]
+                },
+                "b63890eb-b632-4c80-9254-2d010a4322b6": {
+                    "id": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "eval",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 874.1294006574157,
+                    "y": 233.20715990940238,
+                    "ports": [
+                        {
+                            "id": "b76cfe91-1abc-468a-80a2-a461305f7d03",
+                            "type": "default",
+                            "x": 876.1250056349679,
+                            "y": 260.3437372946277,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                            "links": [
+                                "c5befaa5-6e8a-4893-8636-db220d818ced"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "2a9c1595-da2c-4a7f-a392-4cd03094b5e2",
+                            "type": "default",
+                            "x": 876.1250056349679,
+                            "y": 276.34375241838325,
+                            "name": "in-1",
+                            "alignment": "left",
+                            "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                            "links": [
+                                "db28b105-7adf-4a58-aa23-292081aa5eb5"
+                            ],
+                            "in": true,
+                            "label": "model"
+                        },
+                        {
+                            "id": "31a9bc06-d8e9-4ffd-8b92-abc9a27ff36d",
+                            "type": "default",
+                            "x": 876.1250056349679,
+                            "y": 292.3437351340912,
+                            "name": "in-2",
+                            "alignment": "left",
+                            "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                            "links": [
+                                "d9fbe310-056f-4f2d-946a-db172d25a894"
+                            ],
+                            "in": true,
+                            "label": "eval_dataset"
+                        },
+                        {
+                            "id": "339e8673-50f8-4b4b-87c9-4dc76cef6f51",
+                            "type": "default",
+                            "x": 1018.9687902035521,
+                            "y": 260.3437372946277,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                            "links": [
+                                "6c4323fb-e6bb-4587-9dc9-448a9319779c"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "ea4a4199-3c8e-435e-a9b4-eb6cc6962e5d",
+                            "type": "default",
+                            "x": 1018.9687902035521,
+                            "y": 276.34375241838325,
+                            "name": "out-1",
+                            "alignment": "right",
+                            "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
+                            "links": [
+                                "88e64805-f194-4860-86ff-1bf3e5c0ca69"
+                            ],
+                            "in": false,
+                            "label": "metrics"
+                        }
+                    ],
+                    "name": "EvaluateAccuracy",
+                    "color": "rgb(255,204,0)",
+                    "portsInOrder": [
+                        "b76cfe91-1abc-468a-80a2-a461305f7d03",
+                        "2a9c1595-da2c-4a7f-a392-4cd03094b5e2",
+                        "31a9bc06-d8e9-4ffd-8b92-abc9a27ff36d"
+                    ],
+                    "portsOutOrder": [
+                        "339e8673-50f8-4b4b-87c9-4dc76cef6f51",
+                        "ea4a4199-3c8e-435e-a9b4-eb6cc6962e5d"
+                    ]
+                },
+                "bacd83a3-8d6e-4db5-ba21-bd3c25af184d": {
+                    "id": "bacd83a3-8d6e-4db5-ba21-bd3c25af184d",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "float",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": -22.923173940533502,
+                    "y": 224.6368824726505,
+                    "ports": [
+                        {
+                            "id": "31173d23-e739-4784-8444-88e9ba6ba94e",
+                            "type": "default",
+                            "x": 48.562501313894266,
+                            "y": 251.76561877623723,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "bacd83a3-8d6e-4db5-ba21-bd3c25af184d",
+                            "links": [
+                                "a070bc33-7106-4e2f-abdb-f517557b4d07"
+                            ],
+                            "in": false,
+                            "label": "0.8"
+                        }
+                    ],
+                    "name": "Literal Float",
+                    "color": "rgb(153,204,204)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "31173d23-e739-4784-8444-88e9ba6ba94e"
+                    ]
+                },
+                "00c6ced8-6bea-42dc-b37e-ab85f1bc9756": {
+                    "id": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "split",
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 94.74623940908023,
+                    "y": 129.5521418428356,
+                    "ports": [
+                        {
+                            "id": "578de5fc-7321-4a00-b953-2667cc47723a",
+                            "type": "default",
+                            "x": 96.73437415335779,
+                            "y": 156.6875045789197,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [
+                                "c7f41f3d-c452-4536-bf10-3e88b9268549"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "ca05f0cb-1c2b-4ea4-b07c-e0656aa5d7f5",
+                            "type": "default",
+                            "x": 96.73437415335779,
+                            "y": 172.68748729462766,
+                            "name": "in-1",
+                            "alignment": "left",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [
+                                "3b25646a-6c87-4ebd-8413-c35b00abb182"
+                            ],
+                            "in": true,
+                            "label": "dataset"
+                        },
+                        {
+                            "id": "f79849fb-e090-49f1-837a-4f6d2db1c714",
+                            "type": "default",
+                            "x": 96.73437415335779,
+                            "y": 188.6875024183832,
+                            "name": "parameter-float-in-2",
+                            "alignment": "left",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [
+                                "a070bc33-7106-4e2f-abdb-f517557b4d07"
+                            ],
+                            "in": true,
+                            "label": "train_split"
+                        },
+                        {
+                            "id": "8d3e6e81-34e0-4580-be03-2bbbb85a75a9",
+                            "type": "default",
+                            "x": 96.73437415335779,
+                            "y": 204.68751754213875,
+                            "name": "parameter-int-in-3",
+                            "alignment": "left",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [],
+                            "in": true,
+                            "label": "random_state"
+                        },
+                        {
+                            "id": "552aa2f2-c574-4129-b034-097d6fe3e991",
+                            "type": "default",
+                            "x": 96.73437415335779,
+                            "y": 220.68750025784672,
+                            "name": "parameter-boolean-in-4",
+                            "alignment": "left",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [],
+                            "in": true,
+                            "label": "shuffle"
+                        },
+                        {
+                            "id": "465eb792-f0ad-4e11-b459-cec362c7c8c4",
+                            "type": "default",
+                            "x": 230.4062599560404,
+                            "y": 156.6875045789197,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [
+                                "77a86d2e-9257-46a1-9ff0-915fd8fc5300"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
+                            "type": "default",
+                            "x": 230.4062599560404,
+                            "y": 172.68748729462766,
+                            "name": "out-1",
+                            "alignment": "right",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [
+                                "d393f884-ff0a-4c5f-b42c-2caa8705d368",
+                                "5468df02-a360-45ce-89a5-822bd2b7c5e3"
+                            ],
+                            "in": false,
+                            "label": "train"
+                        },
+                        {
+                            "id": "2ecffc71-058b-40a2-b51a-58226f6d3bf4",
+                            "type": "default",
+                            "x": 230.4062599560404,
+                            "y": 188.6875024183832,
+                            "name": "out-2",
+                            "alignment": "right",
+                            "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
+                            "links": [
+                                "d9fbe310-056f-4f2d-946a-db172d25a894"
+                            ],
+                            "in": false,
+                            "label": "test"
+                        }
+                    ],
+                    "name": "TrainTestSplit",
+                    "color": "rgb(0,102,204)",
+                    "portsInOrder": [
+                        "578de5fc-7321-4a00-b953-2667cc47723a",
+                        "ca05f0cb-1c2b-4ea4-b07c-e0656aa5d7f5",
+                        "f79849fb-e090-49f1-837a-4f6d2db1c714",
+                        "8d3e6e81-34e0-4580-be03-2bbbb85a75a9",
+                        "552aa2f2-c574-4129-b034-097d6fe3e991"
+                    ],
+                    "portsOutOrder": [
+                        "465eb792-f0ad-4e11-b459-cec362c7c8c4",
+                        "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
+                        "2ecffc71-058b-40a2-b51a-58226f6d3bf4"
+                    ]
+                },
+                "37e8b213-8bc0-402e-9ba5-0fc02c5fd6af": {
+                    "id": "37e8b213-8bc0-402e-9ba5-0fc02c5fd6af",
+                    "locked": false,
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "string"
+                    },
+                    "x": -321.13988741296544,
+                    "y": 208.51933509022078,
+                    "ports": [
+                        {
+                            "id": "5b11bf77-5061-4aab-879e-d7631cd4b698",
+                            "type": "default",
+                            "x": -245.34374868610595,
+                            "y": 235.65625889999274,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "37e8b213-8bc0-402e-9ba5-0fc02c5fd6af",
+                            "links": [
+                                "e14d15f1-130e-4ea9-977f-7cb96acff519"
+                            ],
+                            "in": false,
+                            "label": "mnist"
+                        }
+                    ],
+                    "name": "Literal String",
+                    "color": "rgb(255,204,0)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "5b11bf77-5061-4aab-879e-d7631cd4b698"
+                    ]
+                },
+                "f0ecb56e-2ed7-4b59-a0c1-677349396625": {
+                    "id": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug",
+                        "borderColor": "red",
+                        "tip": "Please make sure this node ▶ is properly connected "
+                    },
+                    "x": 1334.083995186587,
+                    "y": -41.27142440474382,
+                    "ports": [
+                        {
+                            "id": "d8808a3f-aba3-43e4-9b1f-d0845bac1e24",
+                            "type": "default",
+                            "x": 1336.0781652035523,
+                            "y": -14.125000282287568,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                            "links": [
+                                "96e6b9e8-3fa6-4f14-a9d9-7c2e9549e252"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "ee851724-cfc8-45a2-a037-eb43d7ae99bb",
+                            "type": "default",
+                            "x": 1477.8281133506762,
+                            "y": -14.125000282287568,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                            "links": [
+                                "1e52f7d5-7d20-4869-9c70-bfda0910b079"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "f4f61cb7-aa50-42c4-af7b-80e397037d27",
+                            "type": "default",
+                            "x": 1336.0781652035523,
+                            "y": 1.8750067394560828,
+                            "name": "parameter-string-client_url",
+                            "alignment": "left",
+                            "parentNode": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                            "links": [],
+                            "in": true,
+                            "label": "client_url"
+                        },
+                        {
+                            "id": "44b9fb0f-4567-42ab-9050-4a3337544c75",
+                            "type": "default",
+                            "x": 1336.0781652035523,
+                            "y": 17.87498945516406,
+                            "name": "parameter-string-username",
+                            "alignment": "left",
+                            "parentNode": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                            "links": [
+                                "5d844560-594a-40a4-9a39-424a6916035a"
+                            ],
+                            "in": true,
+                            "label": "★username"
+                        },
+                        {
+                            "id": "2ea24055-2021-4334-b17f-bfc971e52a15",
+                            "type": "default",
+                            "x": 1336.0781652035523,
+                            "y": 33.8750045789196,
+                            "name": "parameter-string-password",
+                            "alignment": "left",
+                            "parentNode": "f0ecb56e-2ed7-4b59-a0c1-677349396625",
+                            "links": [
+                                "007d20a2-ad0b-4fa7-acf7-19e6bb25846f"
+                            ],
+                            "in": true,
+                            "label": "★password"
+                        }
+                    ],
+                    "name": "StartLocalModelStashSession",
+                    "color": "rgb(15,255,255)",
+                    "portsInOrder": [
+                        "d8808a3f-aba3-43e4-9b1f-d0845bac1e24",
+                        "f4f61cb7-aa50-42c4-af7b-80e397037d27",
+                        "44b9fb0f-4567-42ab-9050-4a3337544c75",
+                        "2ea24055-2021-4334-b17f-bfc971e52a15"
+                    ],
+                    "portsOutOrder": [
+                        "ee851724-cfc8-45a2-a037-eb43d7ae99bb"
+                    ]
+                },
+                "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b": {
+                    "id": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug"
+                    },
+                    "x": 1606.3749495084962,
+                    "y": 122.69507387764205,
+                    "ports": [
+                        {
+                            "id": "421d308c-5017-43d5-afb5-ebb2fd63780e",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 149.8281468632117,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [
+                                "1e52f7d5-7d20-4869-9c70-bfda0910b079"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "64a8f308-7603-4690-ab7b-17a7aec98a99",
+                            "type": "default",
+                            "x": 1816.0469238456985,
+                            "y": 149.8281468632117,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [
+                                "49533ce1-56bb-4bc1-9b12-33aa93556e28"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "d7fb88f9-32d8-440f-a2c9-6e658ae8f9b7",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 165.8281295789197,
+                            "name": "parameter-string-model_file_path",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [
+                                "0f9a8920-fb8a-4c8f-88b0-f5d6d2892398"
+                            ],
+                            "in": true,
+                            "label": "★model_file_path"
+                        },
+                        {
+                            "id": "0a9d9c7b-964a-40f9-9b90-f5a1b042a33f",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 181.82811229462766,
+                            "name": "parameter-string-model_name",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": true,
+                            "label": "model_name"
+                        },
+                        {
+                            "id": "f8969390-d7ce-408a-9e5c-865cf64cabda",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 197.8281274183832,
+                            "name": "parameter-string-creator_name",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": true,
+                            "label": "creator_name"
+                        },
+                        {
+                            "id": "24f82bd6-af55-4b13-8b30-0e90845309cf",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 213.82814254213875,
+                            "name": "parameter-string-training_dataset_name",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": true,
+                            "label": "training_dataset_name"
+                        },
+                        {
+                            "id": "f41d52e1-84f6-4f1a-b680-507f104a803e",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 229.82812525784672,
+                            "name": "parameter-any-input_names",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": true,
+                            "label": "input_names"
+                        },
+                        {
+                            "id": "917e8ec7-e4d8-4fa0-822f-265166107f68",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 245.8281079735547,
+                            "name": "parameter-any-output_names",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": true,
+                            "label": "output_names"
+                        },
+                        {
+                            "id": "7744917f-3014-4c2d-9188-68a2e5406f9b",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 261.82812309731025,
+                            "name": "parameter-any-model_config",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [
+                                "d4e9857d-c809-44f9-a2a4-27b55e250e0f"
+                            ],
+                            "in": true,
+                            "label": "model_config"
+                        },
+                        {
+                            "id": "4808e175-eeb0-49e9-92a6-50f8820effa8",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 277.8281382210658,
+                            "name": "parameter-any-training_metric",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [
+                                "93118dc6-8af1-4c2e-b605-86081adf153d"
+                            ],
+                            "in": true,
+                            "label": "training_metric"
+                        },
+                        {
+                            "id": "0f2a751c-0b91-48d4-9c02-e30ccf7418aa",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 293.82812093677376,
+                            "name": "parameter-any-evaluation_metric",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [
+                                "88e64805-f194-4860-86ff-1bf3e5c0ca69"
+                            ],
+                            "in": true,
+                            "label": "evaluation_metric"
+                        },
+                        {
+                            "id": "5265eb9a-13dc-411a-a5ee-e1aee1e27ca1",
+                            "type": "default",
+                            "x": 1608.3749883506764,
+                            "y": 309.8281360605293,
+                            "name": "parameter-string-skill",
+                            "alignment": "left",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": true,
+                            "label": "skill"
+                        },
+                        {
+                            "id": "d8bc9bba-6cb9-473a-a297-47159ad4cb27",
+                            "type": "default",
+                            "x": 1816.0469238456985,
+                            "y": 165.8281295789197,
+                            "name": "parameter-out-any-ms_model",
+                            "alignment": "right",
+                            "parentNode": "f0dfe075-2dc3-44fa-b6ce-3cbf8671f79b",
+                            "links": [],
+                            "in": false,
+                            "label": "ms_model"
+                        }
+                    ],
+                    "name": "UploadToModelStash",
+                    "color": "rgb(255,153,0)",
+                    "portsInOrder": [
+                        "421d308c-5017-43d5-afb5-ebb2fd63780e",
+                        "d7fb88f9-32d8-440f-a2c9-6e658ae8f9b7",
+                        "0a9d9c7b-964a-40f9-9b90-f5a1b042a33f",
+                        "f8969390-d7ce-408a-9e5c-865cf64cabda",
+                        "24f82bd6-af55-4b13-8b30-0e90845309cf",
+                        "f41d52e1-84f6-4f1a-b680-507f104a803e",
+                        "917e8ec7-e4d8-4fa0-822f-265166107f68",
+                        "7744917f-3014-4c2d-9188-68a2e5406f9b",
+                        "4808e175-eeb0-49e9-92a6-50f8820effa8",
+                        "0f2a751c-0b91-48d4-9c02-e30ccf7418aa",
+                        "5265eb9a-13dc-411a-a5ee-e1aee1e27ca1"
+                    ],
+                    "portsOutOrder": [
+                        "64a8f308-7603-4690-ab7b-17a7aec98a99",
+                        "d8bc9bba-6cb9-473a-a297-47159ad4cb27"
+                    ]
+                },
+                "f65421a9-7e82-4528-8807-9613221cab51": {
+                    "id": "f65421a9-7e82-4528-8807-9613221cab51",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "train"
+                    },
+                    "x": 545.2321080958869,
+                    "y": 113.83504141050993,
+                    "ports": [
+                        {
+                            "id": "230fa965-f9fb-4faf-a48f-e39fb229b428",
+                            "type": "default",
+                            "x": 547.2187772403327,
+                            "y": 140.96875889999268,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "805e5008-571e-405a-bfce-b2ce7fbc9a83"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "7f6cb3f3-bcb4-4c00-9efe-00a198f73297",
+                            "type": "default",
+                            "x": 747.5312988456978,
+                            "y": 140.96875889999268,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "c5befaa5-6e8a-4893-8636-db220d818ced",
+                                "557e7902-fa58-4a31-bedb-cda730cf5e39"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "820ae49a-2d6a-4a68-b309-04ef3838c719",
+                            "type": "default",
+                            "x": 547.2187772403327,
+                            "y": 156.96874161570065,
+                            "name": "parameter-keras.Sequential-model",
+                            "alignment": "left",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "9f1bd30c-0146-4bf9-bcbb-83a96ae1d6a7"
+                            ],
+                            "in": true,
+                            "label": "model"
+                        },
+                        {
+                            "id": "f01b7d9b-5fcb-4b2a-b31d-587fee7e6c43",
+                            "type": "default",
+                            "x": 547.2187772403327,
+                            "y": 172.96872433140862,
+                            "name": "parameter-Tuple[np.array, np.array]-training_data",
+                            "alignment": "left",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "d393f884-ff0a-4c5f-b42c-2caa8705d368"
+                            ],
+                            "in": true,
+                            "label": "training_data"
+                        },
+                        {
+                            "id": "0d5a596a-495c-4ec9-8cdd-0ffd58267db2",
+                            "type": "default",
+                            "x": 547.2187772403327,
+                            "y": 188.96877186321174,
+                            "name": "parameter-int-training_epochs",
+                            "alignment": "left",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "572afe99-7175-4293-913d-0307ff21b853"
+                            ],
+                            "in": true,
+                            "label": "training_epochs"
+                        },
+                        {
+                            "id": "6efa391f-2e0d-4433-8c6d-2062a1089d20",
+                            "type": "default",
+                            "x": 747.5312988456978,
+                            "y": 156.96874161570065,
+                            "name": "parameter-out-keras.Sequential-trained_model",
+                            "alignment": "right",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "db28b105-7adf-4a58-aa23-292081aa5eb5",
+                                "e19b5428-9db2-4962-9d13-bc989246064c"
+                            ],
+                            "in": false,
+                            "label": "trained_model"
+                        },
+                        {
+                            "id": "a50cc20a-1604-495d-a6d3-2c6d9e3d9b49",
+                            "type": "default",
+                            "x": 747.5312988456978,
+                            "y": 172.96872433140862,
+                            "name": "parameter-out-dict-training_metrics",
+                            "alignment": "right",
+                            "parentNode": "f65421a9-7e82-4528-8807-9613221cab51",
+                            "links": [
+                                "93118dc6-8af1-4c2e-b605-86081adf153d"
+                            ],
+                            "in": false,
+                            "label": "training_metrics"
+                        }
+                    ],
+                    "name": "TrainImageClassifier",
+                    "color": "rgb(51,51,51)",
+                    "portsInOrder": [
+                        "230fa965-f9fb-4faf-a48f-e39fb229b428",
+                        "820ae49a-2d6a-4a68-b309-04ef3838c719",
+                        "f01b7d9b-5fcb-4b2a-b31d-587fee7e6c43",
+                        "0d5a596a-495c-4ec9-8cdd-0ffd58267db2"
+                    ],
+                    "portsOutOrder": [
+                        "7f6cb3f3-bcb4-4c00-9efe-00a198f73297",
+                        "6efa391f-2e0d-4433-8c6d-2062a1089d20",
+                        "a50cc20a-1604-495d-a6d3-2c6d9e3d9b49"
+                    ]
+                },
+                "62bb0f7b-94cf-4bad-87c7-e6e800ab9953": {
+                    "id": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "model"
+                    },
+                    "x": 287.8653557210013,
+                    "y": 7.09833910156356,
+                    "ports": [
+                        {
+                            "id": "37665a60-944d-444b-86a8-3e5be6853cf4",
+                            "type": "default",
+                            "x": 289.8594065614055,
+                            "y": 34.2343774183831,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                            "links": [
+                                "77a86d2e-9257-46a1-9ff0-915fd8fc5300"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "da2a84c2-aaba-4594-9704-ca68ddcf83f1",
+                            "type": "default",
+                            "x": 463.9062750797961,
+                            "y": 34.2343774183831,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                            "links": [
+                                "805e5008-571e-405a-bfce-b2ce7fbc9a83"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "d6b63430-fb78-4985-be1e-7b13940220b5",
+                            "type": "default",
+                            "x": 289.8594065614055,
+                            "y": 50.234376338114856,
+                            "name": "parameter-Tuple[np.array, np.array]-training_data",
+                            "alignment": "left",
+                            "parentNode": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                            "links": [
+                                "5468df02-a360-45ce-89a5-822bd2b7c5e3"
+                            ],
+                            "in": true,
+                            "label": "training_data"
+                        },
+                        {
+                            "id": "11197882-2a08-4602-a9d8-db67bb986ec0",
+                            "type": "default",
+                            "x": 463.9062750797961,
+                            "y": 50.234376338114856,
+                            "name": "parameter-out-keras.Sequential-model",
+                            "alignment": "right",
+                            "parentNode": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                            "links": [
+                                "9f1bd30c-0146-4bf9-bcbb-83a96ae1d6a7"
+                            ],
+                            "in": false,
+                            "label": "model"
+                        },
+                        {
+                            "id": "0f5d33b4-c364-4788-b4c8-0fe51ccc7ffb",
+                            "type": "default",
+                            "x": 463.9062750797961,
+                            "y": 66.23437525784662,
+                            "name": "parameter-out-dict-model_config",
+                            "alignment": "right",
+                            "parentNode": "62bb0f7b-94cf-4bad-87c7-e6e800ab9953",
+                            "links": [
+                                "d4e9857d-c809-44f9-a2a4-27b55e250e0f"
+                            ],
+                            "in": false,
+                            "label": "model_config"
+                        }
+                    ],
+                    "name": "Create2DInputModel",
+                    "color": "rgb(51,51,51)",
+                    "portsInOrder": [
+                        "37665a60-944d-444b-86a8-3e5be6853cf4",
+                        "d6b63430-fb78-4985-be1e-7b13940220b5"
+                    ],
+                    "portsOutOrder": [
+                        "da2a84c2-aaba-4594-9704-ca68ddcf83f1",
+                        "11197882-2a08-4602-a9d8-db67bb986ec0",
+                        "0f5d33b4-c364-4788-b4c8-0fe51ccc7ffb"
+                    ]
+                },
+                "fbdc1fc8-570e-4b4e-b122-6b202a6ebe3d": {
+                    "id": "fbdc1fc8-570e-4b4e-b122-6b202a6ebe3d",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "int"
+                    },
+                    "x": 422.7358831301496,
+                    "y": 226.27832789251283,
+                    "ports": [
+                        {
+                            "id": "9555acbb-01fa-480d-8d3f-c7f7e9c17d74",
+                            "type": "default",
+                            "x": 504.0156414376501,
+                            "y": 253.40624377623723,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "fbdc1fc8-570e-4b4e-b122-6b202a6ebe3d",
+                            "links": [
+                                "572afe99-7175-4293-913d-0307ff21b853"
+                            ],
+                            "in": false,
+                            "label": "2"
+                        }
+                    ],
+                    "name": "Literal Integer",
+                    "color": "rgb(204,204,204)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "9555acbb-01fa-480d-8d3f-c7f7e9c17d74"
+                    ]
+                },
+                "4258629c-6599-4954-8cfd-ff91068f3d83": {
+                    "id": "4258629c-6599-4954-8cfd-ff91068f3d83",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "string"
+                    },
+                    "x": 1038.0948450117396,
+                    "y": -40.89597867683028,
+                    "ports": [
+                        {
+                            "id": "ff7a7f01-4708-45de-b14f-c6ec5946b5af",
+                            "type": "default",
+                            "x": 1225.734337424238,
+                            "y": -13.74999866188519,
+                            "name": "parameter-out-0",
+                            "alignment": "right",
+                            "parentNode": "4258629c-6599-4954-8cfd-ff91068f3d83",
+                            "links": [
+                                "5d844560-594a-40a4-9a39-424a6916035a"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        }
+                    ],
+                    "name": "Hyperparameter (String): username",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "ff7a7f01-4708-45de-b14f-c6ec5946b5af"
+                    ]
+                },
+                "b4cecdb7-d266-495e-bbc4-4831389f05d4": {
+                    "id": "b4cecdb7-d266-495e-bbc4-4831389f05d4",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "string"
+                    },
+                    "x": 1043.3503194642942,
+                    "y": 11.658765848717167,
+                    "ports": [
+                        {
+                            "id": "0700928f-18eb-43a3-9b53-9f7dbedde041",
+                            "type": "default",
+                            "x": 1229.140552855654,
+                            "y": 38.79687957891961,
+                            "name": "parameter-out-0",
+                            "alignment": "right",
+                            "parentNode": "b4cecdb7-d266-495e-bbc4-4831389f05d4",
+                            "links": [
+                                "007d20a2-ad0b-4fa7-acf7-19e6bb25846f"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        }
+                    ],
+                    "name": "Hyperparameter (String): password",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "0700928f-18eb-43a3-9b53-9f7dbedde041"
+                    ]
+                },
+                "2887e079-059b-49e0-ab3b-8a380ca392ea": {
+                    "id": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "debug"
+                    },
+                    "x": 1083.3505620275428,
+                    "y": 119.1404675209381,
+                    "ports": [
+                        {
+                            "id": "29fc940f-24b5-4959-83de-e4f79f962f7f",
+                            "type": "default",
+                            "x": 1085.343712424238,
+                            "y": 146.26562741838316,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                            "links": [
+                                "6c4323fb-e6bb-4587-9dc9-448a9319779c"
+                            ],
+                            "in": true,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "3c0bc86a-1294-4f3a-b594-eaf15cfa8736",
+                            "type": "default",
+                            "x": 1269.781281561406,
+                            "y": 146.26562741838316,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                            "links": [
+                                "96e6b9e8-3fa6-4f14-a9d9-7c2e9549e252"
+                            ],
+                            "in": false,
+                            "label": "▶"
+                        },
+                        {
+                            "id": "67a69254-fb78-4af0-af88-94c3b46c0501",
+                            "type": "default",
+                            "x": 1085.343712424238,
+                            "y": 162.2656425421387,
+                            "name": "parameter-any-model",
+                            "alignment": "left",
+                            "parentNode": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                            "links": [
+                                "e19b5428-9db2-4962-9d13-bc989246064c"
+                            ],
+                            "in": true,
+                            "label": "model"
+                        },
+                        {
+                            "id": "524d8df7-a958-49ae-9946-a3616d476736",
+                            "type": "default",
+                            "x": 1085.343712424238,
+                            "y": 178.2656252578467,
+                            "name": "parameter-string-model_name",
+                            "alignment": "left",
+                            "parentNode": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                            "links": [],
+                            "in": true,
+                            "label": "model_name"
+                        },
+                        {
+                            "id": "283a0cb1-0c4c-43df-adc0-4ef0210f030d",
+                            "type": "default",
+                            "x": 1269.781281561406,
+                            "y": 162.2656425421387,
+                            "name": "parameter-out-string-model_h5_path",
+                            "alignment": "right",
+                            "parentNode": "2887e079-059b-49e0-ab3b-8a380ca392ea",
+                            "links": [
+                                "0f9a8920-fb8a-4c8f-88b0-f5d6d2892398"
+                            ],
+                            "in": false,
+                            "label": "model_h5_path"
+                        }
+                    ],
+                    "name": "SaveKerasModel",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [
+                        "29fc940f-24b5-4959-83de-e4f79f962f7f",
+                        "67a69254-fb78-4af0-af88-94c3b46c0501",
+                        "524d8df7-a958-49ae-9946-a3616d476736"
+                    ],
+                    "portsOutOrder": [
+                        "3c0bc86a-1294-4f3a-b594-eaf15cfa8736",
+                        "283a0cb1-0c4c-43df-adc0-4ef0210f030d"
+                    ]
+                }
             }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "9b5fac4c-fca0-4dda-adb0-0d86a9a0ef9f": {
-          "id": "9b5fac4c-fca0-4dda-adb0-0d86a9a0ef9f",
-          "type": "default",
-          "source": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "sourcePort": "b2e54885-1f15-4f80-8487-507765847625",
-          "target": "b63890eb-b632-4c80-9254-2d010a4322b6",
-          "targetPort": "2a9c1595-da2c-4a7f-a392-4cd03094b5e2",
-          "points": [
-            {
-              "id": "4f2eb6b6-3bb8-47ce-88c9-8a99176586b9",
-              "type": "point",
-              "x": 736.8977355957031,
-              "y": 183.0454559326172
-            },
-            {
-              "id": "5432f2f7-117f-4ed0-99d1-f3511eff031c",
-              "type": "point",
-              "x": 790.32958984375,
-              "y": 184.0341033935547
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "a070bc33-7106-4e2f-abdb-f517557b4d07": {
-          "id": "a070bc33-7106-4e2f-abdb-f517557b4d07",
-          "type": "default",
-          "source": "bacd83a3-8d6e-4db5-ba21-bd3c25af184d",
-          "sourcePort": "31173d23-e739-4784-8444-88e9ba6ba94e",
-          "target": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "targetPort": "f79849fb-e090-49f1-837a-4f6d2db1c714",
-          "points": [
-            {
-              "id": "97a3cd91-a819-4fd3-9a7d-4578b62507fc",
-              "type": "point",
-              "x": 75.7613525390625,
-              "y": 235.29547119140625
-            },
-            {
-              "id": "428315fa-52b4-4f85-b741-fe823a9848c0",
-              "type": "point",
-              "x": 125.42045593261719,
-              "y": 196.18182373046875
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "d9fbe310-056f-4f2d-946a-db172d25a894": {
-          "id": "d9fbe310-056f-4f2d-946a-db172d25a894",
-          "type": "default",
-          "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "sourcePort": "2ecffc71-058b-40a2-b51a-58226f6d3bf4",
-          "target": "b63890eb-b632-4c80-9254-2d010a4322b6",
-          "targetPort": "31a9bc06-d8e9-4ffd-8b92-abc9a27ff36d",
-          "points": [
-            {
-              "id": "16343326-1821-4404-8c2f-a914e84b4131",
-              "type": "point",
-              "x": 259.06818199157715,
-              "y": 196.18182373046875
-            },
-            {
-              "id": "1867beca-fecd-414a-9630-fabe76f79895",
-              "type": "point",
-              "x": 790.32958984375,
-              "y": 200.0341033935547
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "05e7dc54-285e-46f2-b942-331f6c2c4158": {
-          "id": "05e7dc54-285e-46f2-b942-331f6c2c4158",
-          "type": "default",
-          "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "sourcePort": "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
-          "target": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "targetPort": "925ac595-aa59-4d7d-ac34-f2de4d9022e4",
-          "points": [
-            {
-              "id": "a7ac8149-772f-4f81-8690-9c983a6320cc",
-              "type": "point",
-              "x": 259.06818199157715,
-              "y": 180.18182373046875
-            },
-            {
-              "id": "872068f3-3b1e-4d93-acc3-3a7d247cec9b",
-              "type": "point",
-              "x": 544.5568237304688,
-              "y": 183.0454559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "3d13f9cd-3934-4e6b-b4c7-a9cab4a1ead1": {
-          "id": "3d13f9cd-3934-4e6b-b4c7-a9cab4a1ead1",
-          "type": "default",
-          "source": "14b830d5-84ee-4aa1-af66-7821a605cec1",
-          "sourcePort": "92cc06f4-f8da-456c-aa4f-094e6d37c2cd",
-          "target": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-          "targetPort": "5a6118b8-8e56-41af-96df-68c810da016e",
-          "points": [
-            {
-              "id": "a0223859-5d19-4f73-8562-be83e5905e89",
-              "type": "point",
-              "x": -130.68182373046875,
-              "y": 282.5
-            },
-            {
-              "id": "788ad385-ce45-40c3-8c83-ea43321dd20b",
-              "type": "point",
-              "x": -77.29547119140625,
-              "y": 179.4204559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "a1a486f6-07b8-4df5-b1f1-f50995e944c9": {
-          "id": "a1a486f6-07b8-4df5-b1f1-f50995e944c9",
-          "type": "default",
-          "source": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-          "sourcePort": "5a9ebcf7-d222-47ea-b931-37a877149a01",
-          "target": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "targetPort": "578de5fc-7321-4a00-b953-2667cc47723a",
-          "points": [
-            {
-              "id": "fe464621-6270-474c-a534-a47c5fd5585e",
-              "type": "point",
-              "x": 73.48863220214844,
-              "y": 163.4204559326172
-            },
-            {
-              "id": "7e7d7573-0191-4804-b57d-2296a669a3cd",
-              "type": "point",
-              "x": 125.42045593261719,
-              "y": 164.18182373046875
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "2f84a196-33d0-4cd1-b1be-c456e753b32f": {
-          "id": "2f84a196-33d0-4cd1-b1be-c456e753b32f",
-          "type": "default",
-          "source": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-          "sourcePort": "d396e843-1995-40ed-a2d3-84d0ab687d0f",
-          "target": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "targetPort": "ca05f0cb-1c2b-4ea4-b07c-e0656aa5d7f5",
-          "points": [
-            {
-              "id": "5f21254c-1bcc-4b8e-9890-f3704bad1871",
-              "type": "point",
-              "x": 73.48863220214844,
-              "y": 179.4204559326172
-            },
-            {
-              "id": "48e65731-71ce-4b93-8bf2-9d2819ce6baf",
-              "type": "point",
-              "x": 125.42045593261719,
-              "y": 180.18182373046875
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "0f9048db-c5f8-448e-b907-8fc4d51c5fb6": {
-          "id": "0f9048db-c5f8-448e-b907-8fc4d51c5fb6",
-          "type": "default",
-          "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "sourcePort": "465eb792-f0ad-4e11-b459-cec362c7c8c4",
-          "target": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-          "targetPort": "79b54d64-ffbf-4080-8e6c-e464ad8efefb",
-          "points": [
-            {
-              "id": "f5c261c5-ff27-43f3-a9f6-a930acb2da25",
-              "type": "point",
-              "x": 259.06818199157715,
-              "y": 164.18182373046875
-            },
-            {
-              "id": "34354610-107a-4db9-a26c-8c26756ba77e",
-              "type": "point",
-              "x": 333.6818199157715,
-              "y": 69.03409576416016
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "15b4ef57-20b8-466f-9cdd-735d251b7e93": {
-          "id": "15b4ef57-20b8-466f-9cdd-735d251b7e93",
-          "type": "default",
-          "source": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "sourcePort": "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
-          "target": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-          "targetPort": "07ead884-4678-4911-b842-71e77db53649",
-          "points": [
-            {
-              "id": "328c404b-7532-4605-80d2-7859e2f0dfc5",
-              "type": "point",
-              "x": 259.06818199157715,
-              "y": 180.18182373046875
-            },
-            {
-              "id": "5fe0dd15-acaa-437b-8b1c-287bca8cd3c0",
-              "type": "point",
-              "x": 333.6818199157715,
-              "y": 85.03409576416016
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "9038c34d-0b13-40f3-89d6-7e504c2cbc95": {
-          "id": "9038c34d-0b13-40f3-89d6-7e504c2cbc95",
-          "type": "default",
-          "source": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-          "sourcePort": "3948cd20-4247-4119-9a80-62c4a096bbad",
-          "target": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "targetPort": "0ecba1e0-c6d3-4d09-89fd-6f0b25fdc7c2",
-          "points": [
-            {
-              "id": "d4a1bb28-fc4d-40d4-9760-80e41b5c86df",
-              "type": "point",
-              "x": 472.22727966308594,
-              "y": 69.03409576416016
-            },
-            {
-              "id": "925d2edc-fed1-472f-957a-e8f98d88a92b",
-              "type": "point",
-              "x": 544.5568237304688,
-              "y": 167.0454559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "dbac2c1c-8813-4f68-98a8-6f2e9ecc7bd4": {
-          "id": "dbac2c1c-8813-4f68-98a8-6f2e9ecc7bd4",
-          "type": "default",
-          "source": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-          "sourcePort": "02b1ff59-2fb2-4058-bc78-d888108325ba",
-          "target": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "targetPort": "5a1cad24-faf0-4e55-988a-865341b394e4",
-          "points": [
-            {
-              "id": "eca15da0-7a39-436f-8f22-fb5503e46acd",
-              "type": "point",
-              "x": 472.22727966308594,
-              "y": 85.03409576416016
-            },
-            {
-              "id": "287d3a94-1d3d-4b10-a010-61888dae2a46",
-              "type": "point",
-              "x": 544.5568237304688,
-              "y": 215.0454559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "53f431f1-bf3f-49a0-aacb-36dd5cf1578f": {
-          "id": "53f431f1-bf3f-49a0-aacb-36dd5cf1578f",
-          "type": "default",
-          "source": "b63890eb-b632-4c80-9254-2d010a4322b6",
-          "sourcePort": "339e8673-50f8-4b4b-87c9-4dc76cef6f51",
-          "target": "416cb018-9057-4000-98b7-43cf70f4b866",
-          "targetPort": "73dfecbb-07de-4338-a406-83f537d7a941",
-          "points": [
-            {
-              "id": "40204a1e-5854-430d-8d8b-1c2f097427c5",
-              "type": "point",
-              "x": 933.1364135742188,
-              "y": 168.0341033935547
-            },
-            {
-              "id": "f570e9c3-af7f-483c-a5ea-31649737e303",
-              "type": "point",
-              "x": 1005.70458984375,
-              "y": 167.22727966308594
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "fb4cb9a2-fc3a-4db0-a4e5-bd88c89b5bbc": {
-          "id": "fb4cb9a2-fc3a-4db0-a4e5-bd88c89b5bbc",
-          "type": "default",
-          "source": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-          "sourcePort": "02b1ff59-2fb2-4058-bc78-d888108325ba",
-          "target": "416cb018-9057-4000-98b7-43cf70f4b866",
-          "targetPort": "e93e937b-5600-4ea9-bf10-bb9555d415a1",
-          "points": [
-            {
-              "id": "e8ba2ac8-255b-4004-af8f-c655ed3617f6",
-              "type": "point",
-              "x": 472.22727966308594,
-              "y": 85.03409576416016
-            },
-            {
-              "id": "dbb98c9c-248d-4d08-8407-377e45b22c08",
-              "type": "point",
-              "x": 1005.70458984375,
-              "y": 183.22727966308594
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "f749d9e9-6bc4-43ef-b601-ce88a93e7bd4": {
-          "id": "f749d9e9-6bc4-43ef-b601-ce88a93e7bd4",
-          "type": "default",
-          "source": "416cb018-9057-4000-98b7-43cf70f4b866",
-          "sourcePort": "30ffde89-586c-4d27-96bf-c76cd33f7171",
-          "target": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-          "targetPort": "0fa93996-e611-43ae-9359-a8fb88fbafaf",
-          "points": [
-            {
-              "id": "66dc4337-bd18-49c3-a81f-6a08a2f0ec07",
-              "type": "point",
-              "x": 1162.5909423828125,
-              "y": 167.22727966308594
-            },
-            {
-              "id": "9d2577c8-2df2-4e34-953d-c0ee91f09807",
-              "type": "point",
-              "x": 1241.4432373046875,
-              "y": 166.02273559570312
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "a01bcde0-7717-4e89-9259-033f2f791132": {
-          "id": "a01bcde0-7717-4e89-9259-033f2f791132",
-          "type": "default",
-          "source": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-          "sourcePort": "220ac01e-17fd-49f6-aba4-c1d922ed7fd0",
-          "target": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-          "targetPort": "06cabd36-1462-4145-8461-0ecde0f02199",
-          "points": [
-            {
-              "id": "3bd454f0-93b3-4238-8f64-8c191adf96a8",
-              "type": "point",
-              "x": 1369.875,
-              "y": 166.02273559570312
-            },
-            {
-              "id": "8e489d43-2930-4e82-a583-af21ef177c3e",
-              "type": "point",
-              "x": 1415.477294921875,
-              "y": 167.6704559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "b2662d1e-aa22-47c3-abe7-d9920a346a2e": {
-          "id": "b2662d1e-aa22-47c3-abe7-d9920a346a2e",
-          "type": "default",
-          "source": "416cb018-9057-4000-98b7-43cf70f4b866",
-          "sourcePort": "c6e8a134-ac87-40ef-9de6-6fdf9f5ffb31",
-          "target": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-          "targetPort": "28ab3eb4-f923-4ea0-a434-9d831bdd9a42",
-          "points": [
-            {
-              "id": "8c2eefc6-b334-4c64-89ef-429c8392e42c",
-              "type": "point",
-              "x": 1162.5909423828125,
-              "y": 183.22727966308594
-            },
-            {
-              "id": "73c04e4e-4f3d-4a35-bdae-fe771f0bdce8",
-              "type": "point",
-              "x": 1415.477294921875,
-              "y": 183.6704559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "ebf0d808-58cd-42a2-b71e-e54559f7765b": {
-          "id": "ebf0d808-58cd-42a2-b71e-e54559f7765b",
-          "type": "default",
-          "source": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-          "sourcePort": "7852fcbc-a717-48fe-a27e-9a970bbe8c72",
-          "target": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
-          "targetPort": "82ffb26d-208f-4c04-8b2c-c5342aae2641",
-          "points": [
-            {
-              "id": "f49be182-2be9-4c92-b8b8-9a93b73b904c",
-              "type": "point",
-              "x": 1623.07958984375,
-              "y": 167.6704559326172
-            },
-            {
-              "id": "c0ed2adf-3cc6-4d02-85e7-16bf5f82d351",
-              "type": "point",
-              "x": 1692.5909423828125,
-              "y": 162.22727966308594
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "c8c99aac-5162-4e64-83b3-d40f66defa3a": {
-          "id": "c8c99aac-5162-4e64-83b3-d40f66defa3a",
-          "type": "default",
-          "source": "f42ed9b4-f8c2-48fd-a1ee-366474d8e666",
-          "sourcePort": "929e94e1-0e7c-450a-bdb3-2af34880a8a9",
-          "target": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "targetPort": "a6462b54-753c-4688-9347-a7ebbd863121",
-          "points": [
-            {
-              "id": "dd0f9b02-ff08-4d92-91a8-d71dbf430fc7",
-              "type": "point",
-              "x": 484.7841033935547,
-              "y": 223.625
-            },
-            {
-              "id": "5ca3f173-b138-460e-8206-02adf9e6fc3c",
-              "type": "point",
-              "x": 544.5568237304688,
-              "y": 199.0454559326172
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "3e312605-b1b9-427f-9c0c-d58a522e4a36": {
-          "id": "3e312605-b1b9-427f-9c0c-d58a522e4a36",
-          "type": "default",
-          "source": "14b830d5-84ee-4aa1-af66-7821a605cec1",
-          "sourcePort": "92cc06f4-f8da-456c-aa4f-094e6d37c2cd",
-          "target": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-          "targetPort": "0fdf1e33-7a88-436d-a6af-7048aba345f8",
-          "points": [
-            {
-              "id": "afa27986-1868-4f96-8b6b-0ea869ca6a2c",
-              "type": "point",
-              "x": -130.68182373046875,
-              "y": 282.5
-            },
-            {
-              "id": "ca5b63c3-5c27-4400-ae82-5ef26a5bdb8d",
-              "type": "point",
-              "x": 1415.477294921875,
-              "y": 231.67047119140625
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "00e79a61-f3c9-42dd-a18b-b838ba946f9c": {
-          "id": "00e79a61-f3c9-42dd-a18b-b838ba946f9c",
-          "type": "default",
-          "source": "66344a48-55c3-4851-a022-b579cf0acfe3",
-          "sourcePort": "eb5d0a0b-06f3-4533-a2c6-9d40597ec8da",
-          "target": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-          "targetPort": "508b6362-a5f2-4ace-8215-6745194e6737",
-          "points": [
-            {
-              "id": "a4b87ead-e29e-4b8e-98be-ea6fcb1e4049",
-              "type": "point",
-              "x": 1169.8068237304688,
-              "y": 310.0340881347656
-            },
-            {
-              "id": "da0525ca-36ef-426b-aec4-54052b107457",
-              "type": "point",
-              "x": 1241.4432373046875,
-              "y": 214.02273559570312
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
-        },
-        "8eca32d4-52a3-4b28-8df0-6d51a35bdabb": {
-          "id": "8eca32d4-52a3-4b28-8df0-6d51a35bdabb",
-          "type": "default",
-          "source": "5eeaece6-7beb-46f1-b50d-aadcdcb434d2",
-          "sourcePort": "28ceb49d-924d-4ec4-8eeb-8f9b9a00259b",
-          "target": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-          "targetPort": "a9417fb8-2aaa-4d80-8fd3-e078d552218b",
-          "points": [
-            {
-              "id": "4e63eb9d-edbe-4d04-a0dd-efe5dc971fa2",
-              "type": "point",
-              "x": 1168.9659423828125,
-              "y": 257.31817626953125
-            },
-            {
-              "id": "84a72846-cdc7-490e-99e1-6a1bbbc130e5",
-              "type": "point",
-              "x": 1241.4432373046875,
-              "y": 198.02273559570312
-            }
-          ],
-          "labels": [],
-          "width": 3,
-          "color": "gray",
-          "curvyness": 50,
-          "selectedColor": "rgb(0,192,255)"
         }
-      }
-    },
-    {
-      "id": "38a1e357-4abe-4755-944f-cdcadba9c59f",
-      "type": "diagram-nodes",
-      "isSvg": false,
-      "transformed": true,
-      "models": {
-        "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8": {
-          "id": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
-          "type": "custom-node",
-          "extras": {
-            "type": "Start"
-          },
-          "x": -177.55532848256908,
-          "y": 61.433035810666844,
-          "ports": [
-            {
-              "id": "ea0d5274-a264-4e83-be99-98dfd344b694",
-              "type": "default",
-              "x": -146.09091186523438,
-              "y": 88.56818389892578,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
-              "links": [
-                "932683ce-2715-4e56-80ec-f5dc617d1715"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "1f742844-3d9b-4818-a7c3-4daba263ff78",
-              "type": "default",
-              "x": -146.09091186523438,
-              "y": 104.56819152832031,
-              "name": "parameter-out-1",
-              "alignment": "right",
-              "parentNode": "8ec5f3e7-30bc-4ffe-9362-99a9a7475fe8",
-              "links": [],
-              "in": false,
-              "label": "  "
-            }
-          ],
-          "name": "Start",
-          "color": "rgb(255,102,102)",
-          "portsInOrder": [],
-          "portsOutOrder": [
-            "ea0d5274-a264-4e83-be99-98dfd344b694",
-            "1f742844-3d9b-4818-a7c3-4daba263ff78"
-          ]
-        },
-        "b9e041cf-27c7-4488-ada4-6623adb0ab30": {
-          "id": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
-          "type": "custom-node",
-          "extras": {
-            "type": "Finish",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 1683.0975432284813,
-          "y": 127.59372485307188,
-          "ports": [
-            {
-              "id": "82ffb26d-208f-4c04-8b2c-c5342aae2641",
-              "type": "default",
-              "x": 1685.0909423828125,
-              "y": 154.72727966308594,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
-              "links": [
-                "ebf0d808-58cd-42a2-b71e-e54559f7765b"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "e8a1caeb-514f-4d71-8afa-77d5cf4dac5e",
-              "type": "default",
-              "x": 1685.0909423828125,
-              "y": 170.72727966308594,
-              "name": "parameter-in-1",
-              "alignment": "left",
-              "parentNode": "b9e041cf-27c7-4488-ada4-6623adb0ab30",
-              "links": [],
-              "in": true,
-              "label": "  "
-            }
-          ],
-          "name": "Finish",
-          "color": "rgb(255,102,102)",
-          "portsInOrder": [
-            "82ffb26d-208f-4c04-8b2c-c5342aae2641",
-            "e8a1caeb-514f-4d71-8afa-77d5cf4dac5e"
-          ],
-          "portsOutOrder": []
-        },
-        "d0d51a3e-7356-4237-8dbc-65d0f395b2fd": {
-          "id": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-          "type": "custom-node",
-          "extras": {
-            "type": "in",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": -86.80033213305049,
-          "y": 128.79302097793686,
-          "ports": [
-            {
-              "id": "153f23c1-e13d-4de9-aaa2-e6f5076653c8",
-              "type": "default",
-              "x": -84.79547119140625,
-              "y": 155.9204559326172,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-              "links": [
-                "932683ce-2715-4e56-80ec-f5dc617d1715"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "5a6118b8-8e56-41af-96df-68c810da016e",
-              "type": "default",
-              "x": -84.79547119140625,
-              "y": 171.9204559326172,
-              "name": "parameter-string-in-1",
-              "alignment": "left",
-              "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-              "links": [
-                "3d13f9cd-3934-4e6b-b4c7-a9cab4a1ead1"
-              ],
-              "in": true,
-              "label": "dataset_name"
-            },
-            {
-              "id": "5a9ebcf7-d222-47ea-b931-37a877149a01",
-              "type": "default",
-              "x": 65.98863220214844,
-              "y": 155.9204559326172,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-              "links": [
-                "a1a486f6-07b8-4df5-b1f1-f50995e944c9"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "d396e843-1995-40ed-a2d3-84d0ab687d0f",
-              "type": "default",
-              "x": 65.98863220214844,
-              "y": 171.9204559326172,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "d0d51a3e-7356-4237-8dbc-65d0f395b2fd",
-              "links": [
-                "2f84a196-33d0-4cd1-b1be-c456e753b32f"
-              ],
-              "in": false,
-              "label": "dataset"
-            }
-          ],
-          "name": "ReadDataSet",
-          "color": "rgb(255,102,102)",
-          "portsInOrder": [
-            "153f23c1-e13d-4de9-aaa2-e6f5076653c8",
-            "5a6118b8-8e56-41af-96df-68c810da016e"
-          ],
-          "portsOutOrder": [
-            "5a9ebcf7-d222-47ea-b931-37a877149a01",
-            "d396e843-1995-40ed-a2d3-84d0ab687d0f"
-          ]
-        },
-        "105d5c92-1001-4852-9b57-1b83cb5fee6a": {
-          "id": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-          "type": "custom-node",
-          "extras": {
-            "type": "train",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 535.0634275873966,
-          "y": 132.4099846943501,
-          "ports": [
-            {
-              "id": "0ecba1e0-c6d3-4d09-89fd-6f0b25fdc7c2",
-              "type": "default",
-              "x": 537.0568237304688,
-              "y": 159.5454559326172,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-              "links": [
-                "9038c34d-0b13-40f3-89d6-7e504c2cbc95"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "925ac595-aa59-4d7d-ac34-f2de4d9022e4",
-              "type": "default",
-              "x": 537.0568237304688,
-              "y": 175.5454559326172,
-              "name": "in-1",
-              "alignment": "left",
-              "parentNode": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-              "links": [
-                "05e7dc54-285e-46f2-b942-331f6c2c4158"
-              ],
-              "in": true,
-              "label": "training_data"
-            },
-            {
-              "id": "a6462b54-753c-4688-9347-a7ebbd863121",
-              "type": "default",
-              "x": 537.0568237304688,
-              "y": 191.5454559326172,
-              "name": "parameter-int-in-2",
-              "alignment": "left",
-              "parentNode": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-              "links": [
-                "c8c99aac-5162-4e64-83b3-d40f66defa3a"
-              ],
-              "in": true,
-              "label": "training_epochs"
-            },
-            {
-              "id": "5a1cad24-faf0-4e55-988a-865341b394e4",
-              "type": "default",
-              "x": 537.0568237304688,
-              "y": 207.5454559326172,
-              "name": "in-3",
-              "alignment": "left",
-              "parentNode": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-              "links": [
-                "dbac2c1c-8813-4f68-98a8-6f2e9ecc7bd4"
-              ],
-              "in": true,
-              "label": "model"
-            },
-            {
-              "id": "5ff15ca1-ac79-4dbd-ad5a-3b614ea5306a",
-              "type": "default",
-              "x": 729.3977355957031,
-              "y": 159.5454559326172,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-              "links": [
-                "1dbe308f-36de-4235-93e5-a5b8abebb169"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "b2e54885-1f15-4f80-8487-507765847625",
-              "type": "default",
-              "x": 729.3977355957031,
-              "y": 175.5454559326172,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "105d5c92-1001-4852-9b57-1b83cb5fee6a",
-              "links": [
-                "9b5fac4c-fca0-4dda-adb0-0d86a9a0ef9f"
-              ],
-              "in": false,
-              "label": "trained_model"
-            }
-          ],
-          "name": "TrainImageClassifier",
-          "color": "rgb(255,153,0)",
-          "portsInOrder": [
-            "0ecba1e0-c6d3-4d09-89fd-6f0b25fdc7c2",
-            "925ac595-aa59-4d7d-ac34-f2de4d9022e4",
-            "a6462b54-753c-4688-9347-a7ebbd863121",
-            "5a1cad24-faf0-4e55-988a-865341b394e4"
-          ],
-          "portsOutOrder": [
-            "5ff15ca1-ac79-4dbd-ad5a-3b614ea5306a",
-            "b2e54885-1f15-4f80-8487-507765847625"
-          ]
-        },
-        "b63890eb-b632-4c80-9254-2d010a4322b6": {
-          "id": "b63890eb-b632-4c80-9254-2d010a4322b6",
-          "type": "custom-node",
-          "extras": {
-            "type": "eval",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 780.8308149885662,
-          "y": 133.40815254798733,
-          "ports": [
-            {
-              "id": "b76cfe91-1abc-468a-80a2-a461305f7d03",
-              "type": "default",
-              "x": 782.82958984375,
-              "y": 160.5341033935547,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
-              "links": [
-                "1dbe308f-36de-4235-93e5-a5b8abebb169"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "2a9c1595-da2c-4a7f-a392-4cd03094b5e2",
-              "type": "default",
-              "x": 782.82958984375,
-              "y": 176.5341033935547,
-              "name": "in-1",
-              "alignment": "left",
-              "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
-              "links": [
-                "9b5fac4c-fca0-4dda-adb0-0d86a9a0ef9f"
-              ],
-              "in": true,
-              "label": "model"
-            },
-            {
-              "id": "31a9bc06-d8e9-4ffd-8b92-abc9a27ff36d",
-              "type": "default",
-              "x": 782.82958984375,
-              "y": 192.5341033935547,
-              "name": "in-2",
-              "alignment": "left",
-              "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
-              "links": [
-                "d9fbe310-056f-4f2d-946a-db172d25a894"
-              ],
-              "in": true,
-              "label": "eval_dataset"
-            },
-            {
-              "id": "339e8673-50f8-4b4b-87c9-4dc76cef6f51",
-              "type": "default",
-              "x": 925.6364135742188,
-              "y": 160.5341033935547,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
-              "links": [
-                "53f431f1-bf3f-49a0-aacb-36dd5cf1578f"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "ea4a4199-3c8e-435e-a9b4-eb6cc6962e5d",
-              "type": "default",
-              "x": 925.6364135742188,
-              "y": 176.5341033935547,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "b63890eb-b632-4c80-9254-2d010a4322b6",
-              "links": [],
-              "in": false,
-              "label": "metrics"
-            }
-          ],
-          "name": "EvaluateAccuracy",
-          "color": "rgb(255,204,0)",
-          "portsInOrder": [
-            "b76cfe91-1abc-468a-80a2-a461305f7d03",
-            "2a9c1595-da2c-4a7f-a392-4cd03094b5e2",
-            "31a9bc06-d8e9-4ffd-8b92-abc9a27ff36d"
-          ],
-          "portsOutOrder": [
-            "339e8673-50f8-4b4b-87c9-4dc76cef6f51",
-            "ea4a4199-3c8e-435e-a9b4-eb6cc6962e5d"
-          ]
-        },
-        "bacd83a3-8d6e-4db5-ba21-bd3c25af184d": {
-          "id": "bacd83a3-8d6e-4db5-ba21-bd3c25af184d",
-          "type": "custom-node",
-          "extras": {
-            "type": "float",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 0.8172064221378894,
-          "y": 200.66739994279646,
-          "ports": [
-            {
-              "id": "31173d23-e739-4784-8444-88e9ba6ba94e",
-              "type": "default",
-              "x": 68.2613525390625,
-              "y": 227.79547119140625,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "bacd83a3-8d6e-4db5-ba21-bd3c25af184d",
-              "links": [
-                "a070bc33-7106-4e2f-abdb-f517557b4d07"
-              ],
-              "in": false,
-              "label": "0.8"
-            }
-          ],
-          "name": "Literal Float",
-          "color": "rgb(153,204,204)",
-          "portsInOrder": [],
-          "portsOutOrder": [
-            "31173d23-e739-4784-8444-88e9ba6ba94e"
-          ]
-        },
-        "00c6ced8-6bea-42dc-b37e-ab85f1bc9756": {
-          "id": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-          "type": "custom-node",
-          "extras": {
-            "type": "split",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 115.92270999731554,
-          "y": 129.5521418428356,
-          "ports": [
-            {
-              "id": "578de5fc-7321-4a00-b953-2667cc47723a",
-              "type": "default",
-              "x": 117.92045593261719,
-              "y": 156.68182373046875,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [
-                "a1a486f6-07b8-4df5-b1f1-f50995e944c9"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "ca05f0cb-1c2b-4ea4-b07c-e0656aa5d7f5",
-              "type": "default",
-              "x": 117.92045593261719,
-              "y": 172.68182373046875,
-              "name": "in-1",
-              "alignment": "left",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [
-                "2f84a196-33d0-4cd1-b1be-c456e753b32f"
-              ],
-              "in": true,
-              "label": "dataset"
-            },
-            {
-              "id": "f79849fb-e090-49f1-837a-4f6d2db1c714",
-              "type": "default",
-              "x": 117.92045593261719,
-              "y": 188.68182373046875,
-              "name": "parameter-float-in-2",
-              "alignment": "left",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [
-                "a070bc33-7106-4e2f-abdb-f517557b4d07"
-              ],
-              "in": true,
-              "label": "train_split"
-            },
-            {
-              "id": "8d3e6e81-34e0-4580-be03-2bbbb85a75a9",
-              "type": "default",
-              "x": 117.92045593261719,
-              "y": 204.68182373046875,
-              "name": "parameter-int-in-3",
-              "alignment": "left",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [],
-              "in": true,
-              "label": "random_state"
-            },
-            {
-              "id": "552aa2f2-c574-4129-b034-097d6fe3e991",
-              "type": "default",
-              "x": 117.92045593261719,
-              "y": 220.68182373046875,
-              "name": "parameter-boolean-in-4",
-              "alignment": "left",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [],
-              "in": true,
-              "label": "shuffle"
-            },
-            {
-              "id": "465eb792-f0ad-4e11-b459-cec362c7c8c4",
-              "type": "default",
-              "x": 251.56818199157715,
-              "y": 156.68182373046875,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [
-                "0f9048db-c5f8-448e-b907-8fc4d51c5fb6"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
-              "type": "default",
-              "x": 251.56818199157715,
-              "y": 172.68182373046875,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [
-                "05e7dc54-285e-46f2-b942-331f6c2c4158",
-                "15b4ef57-20b8-466f-9cdd-735d251b7e93"
-              ],
-              "in": false,
-              "label": "train"
-            },
-            {
-              "id": "2ecffc71-058b-40a2-b51a-58226f6d3bf4",
-              "type": "default",
-              "x": 251.56818199157715,
-              "y": 188.68182373046875,
-              "name": "out-2",
-              "alignment": "right",
-              "parentNode": "00c6ced8-6bea-42dc-b37e-ab85f1bc9756",
-              "links": [
-                "d9fbe310-056f-4f2d-946a-db172d25a894"
-              ],
-              "in": false,
-              "label": "test"
-            }
-          ],
-          "name": "TrainTestSplit",
-          "color": "rgb(0,102,204)",
-          "portsInOrder": [
-            "578de5fc-7321-4a00-b953-2667cc47723a",
-            "ca05f0cb-1c2b-4ea4-b07c-e0656aa5d7f5",
-            "f79849fb-e090-49f1-837a-4f6d2db1c714",
-            "8d3e6e81-34e0-4580-be03-2bbbb85a75a9",
-            "552aa2f2-c574-4129-b034-097d6fe3e991"
-          ],
-          "portsOutOrder": [
-            "465eb792-f0ad-4e11-b459-cec362c7c8c4",
-            "c942b6a6-c299-4d2d-b89b-75f4081c66b3",
-            "2ecffc71-058b-40a2-b51a-58226f6d3bf4"
-          ]
-        },
-        "14b830d5-84ee-4aa1-af66-7821a605cec1": {
-          "id": "14b830d5-84ee-4aa1-af66-7821a605cec1",
-          "type": "custom-node",
-          "extras": {
-            "type": "string",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": -287.95034050127134,
-          "y": 247.86900686766893,
-          "ports": [
-            {
-              "id": "92cc06f4-f8da-456c-aa4f-094e6d37c2cd",
-              "type": "default",
-              "x": -138.18182373046875,
-              "y": 275,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "14b830d5-84ee-4aa1-af66-7821a605cec1",
-              "links": [
-                "3d13f9cd-3934-4e6b-b4c7-a9cab4a1ead1",
-                "3e312605-b1b9-427f-9c0c-d58a522e4a36"
-              ],
-              "in": false,
-              "label": "Datasets/weather_dataset"
-            }
-          ],
-          "name": "Literal String",
-          "color": "rgb(255,204,0)",
-          "portsInOrder": [],
-          "portsOutOrder": [
-            "92cc06f4-f8da-456c-aa4f-094e6d37c2cd"
-          ]
-        },
-        "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6": {
-          "id": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-          "type": "custom-node",
-          "extras": {
-            "type": "debug",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 324.19166342603194,
-          "y": 34.402451455618504,
-          "ports": [
-            {
-              "id": "79b54d64-ffbf-4080-8e6c-e464ad8efefb",
-              "type": "default",
-              "x": 326.1818199157715,
-              "y": 61.534095764160156,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-              "links": [
-                "0f9048db-c5f8-448e-b907-8fc4d51c5fb6"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "07ead884-4678-4911-b842-71e77db53649",
-              "type": "default",
-              "x": 326.1818199157715,
-              "y": 77.53409576416016,
-              "name": "in-1",
-              "alignment": "left",
-              "parentNode": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-              "links": [
-                "15b4ef57-20b8-466f-9cdd-735d251b7e93"
-              ],
-              "in": true,
-              "label": "training_data"
-            },
-            {
-              "id": "3948cd20-4247-4119-9a80-62c4a096bbad",
-              "type": "default",
-              "x": 464.72727966308594,
-              "y": 61.534095764160156,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-              "links": [
-                "9038c34d-0b13-40f3-89d6-7e504c2cbc95"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "02b1ff59-2fb2-4058-bc78-d888108325ba",
-              "type": "default",
-              "x": 464.72727966308594,
-              "y": 77.53409576416016,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "b4b91ab7-dd3e-4cb6-9e10-f5c2d64eead6",
-              "links": [
-                "dbac2c1c-8813-4f68-98a8-6f2e9ecc7bd4",
-                "fb4cb9a2-fc3a-4db0-a4e5-bd88c89b5bbc"
-              ],
-              "in": false,
-              "label": "model"
-            }
-          ],
-          "name": "Create2DInputModel",
-          "color": "rgb(255,102,102)",
-          "portsInOrder": [
-            "79b54d64-ffbf-4080-8e6c-e464ad8efefb",
-            "07ead884-4678-4911-b842-71e77db53649"
-          ],
-          "portsOutOrder": [
-            "3948cd20-4247-4119-9a80-62c4a096bbad",
-            "02b1ff59-2fb2-4058-bc78-d888108325ba"
-          ]
-        },
-        "416cb018-9057-4000-98b7-43cf70f4b866": {
-          "id": "416cb018-9057-4000-98b7-43cf70f4b866",
-          "type": "custom-node",
-          "extras": {
-            "type": "debug",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 996.2100765175211,
-          "y": 132.59175134780747,
-          "ports": [
-            {
-              "id": "73dfecbb-07de-4338-a406-83f537d7a941",
-              "type": "default",
-              "x": 998.20458984375,
-              "y": 159.72727966308594,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "416cb018-9057-4000-98b7-43cf70f4b866",
-              "links": [
-                "53f431f1-bf3f-49a0-aacb-36dd5cf1578f"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "e93e937b-5600-4ea9-bf10-bb9555d415a1",
-              "type": "default",
-              "x": 998.20458984375,
-              "y": 175.72727966308594,
-              "name": "in-1",
-              "alignment": "left",
-              "parentNode": "416cb018-9057-4000-98b7-43cf70f4b866",
-              "links": [
-                "fb4cb9a2-fc3a-4db0-a4e5-bd88c89b5bbc"
-              ],
-              "in": true,
-              "label": "model"
-            },
-            {
-              "id": "431fa284-ade7-4913-bc2d-6cdfde0374ee",
-              "type": "default",
-              "x": 998.20458984375,
-              "y": 191.72727966308594,
-              "name": "parameter-string-in-2",
-              "alignment": "left",
-              "parentNode": "416cb018-9057-4000-98b7-43cf70f4b866",
-              "links": [],
-              "in": true,
-              "label": "model_name"
-            },
-            {
-              "id": "30ffde89-586c-4d27-96bf-c76cd33f7171",
-              "type": "default",
-              "x": 1155.0909423828125,
-              "y": 159.72727966308594,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "416cb018-9057-4000-98b7-43cf70f4b866",
-              "links": [
-                "f749d9e9-6bc4-43ef-b601-ce88a93e7bd4"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "c6e8a134-ac87-40ef-9de6-6fdf9f5ffb31",
-              "type": "default",
-              "x": 1155.0909423828125,
-              "y": 175.72727966308594,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "416cb018-9057-4000-98b7-43cf70f4b866",
-              "links": [
-                "b2662d1e-aa22-47c3-abe7-d9920a346a2e"
-              ],
-              "in": false,
-              "label": "model_h5"
-            }
-          ],
-          "name": "SaveKerasModel",
-          "color": "rgb(255,153,0)",
-          "portsInOrder": [
-            "73dfecbb-07de-4338-a406-83f537d7a941",
-            "e93e937b-5600-4ea9-bf10-bb9555d415a1",
-            "431fa284-ade7-4913-bc2d-6cdfde0374ee"
-          ],
-          "portsOutOrder": [
-            "30ffde89-586c-4d27-96bf-c76cd33f7171",
-            "c6e8a134-ac87-40ef-9de6-6fdf9f5ffb31"
-          ]
-        },
-        "34b4154e-67c0-4921-89cc-fb7fd7116702": {
-          "id": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-          "type": "custom-node",
-          "extras": {
-            "type": "debug",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 1231.9527213652282,
-          "y": 131.3883993382932,
-          "ports": [
-            {
-              "id": "0fa93996-e611-43ae-9359-a8fb88fbafaf",
-              "type": "default",
-              "x": 1233.9432373046875,
-              "y": 158.52273559570312,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-              "links": [
-                "f749d9e9-6bc4-43ef-b601-ce88a93e7bd4"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "cb0927dc-e4b0-4185-997a-7537d0ff738e",
-              "type": "default",
-              "x": 1233.9432373046875,
-              "y": 174.52273559570312,
-              "name": "parameter-string-in-1",
-              "alignment": "left",
-              "parentNode": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-              "links": [],
-              "in": true,
-              "label": "client_url"
-            },
-            {
-              "id": "a9417fb8-2aaa-4d80-8fd3-e078d552218b",
-              "type": "default",
-              "x": 1233.9432373046875,
-              "y": 190.52273559570312,
-              "name": "parameter-string-in-2",
-              "alignment": "left",
-              "parentNode": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-              "links": [
-                "8eca32d4-52a3-4b28-8df0-6d51a35bdabb"
-              ],
-              "in": true,
-              "label": "username"
-            },
-            {
-              "id": "508b6362-a5f2-4ace-8215-6745194e6737",
-              "type": "default",
-              "x": 1233.9432373046875,
-              "y": 206.52273559570312,
-              "name": "parameter-string-in-3",
-              "alignment": "left",
-              "parentNode": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-              "links": [
-                "00e79a61-f3c9-42dd-a18b-b838ba946f9c"
-              ],
-              "in": true,
-              "label": "password"
-            },
-            {
-              "id": "220ac01e-17fd-49f6-aba4-c1d922ed7fd0",
-              "type": "default",
-              "x": 1362.375,
-              "y": 158.52273559570312,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "34b4154e-67c0-4921-89cc-fb7fd7116702",
-              "links": [
-                "a01bcde0-7717-4e89-9259-033f2f791132"
-              ],
-              "in": false,
-              "label": "▶"
-            }
-          ],
-          "name": "StartModelStashSession",
-          "color": "rgb(204,204,204)",
-          "portsInOrder": [
-            "0fa93996-e611-43ae-9359-a8fb88fbafaf",
-            "cb0927dc-e4b0-4185-997a-7537d0ff738e",
-            "a9417fb8-2aaa-4d80-8fd3-e078d552218b",
-            "508b6362-a5f2-4ace-8215-6745194e6737"
-          ],
-          "portsOutOrder": [
-            "220ac01e-17fd-49f6-aba4-c1d922ed7fd0"
-          ]
-        },
-        "dc037fda-aef3-4d34-89ce-1396b1b5c1fe": {
-          "id": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-          "type": "custom-node",
-          "selected": false,
-          "extras": {
-            "type": "debug",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 1405.9830745878212,
-          "y": 133.03562590712005,
-          "ports": [
-            {
-              "id": "06cabd36-1462-4145-8461-0ecde0f02199",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 160.1704559326172,
-              "name": "in-0",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [
-                "a01bcde0-7717-4e89-9259-033f2f791132"
-              ],
-              "in": true,
-              "label": "▶"
-            },
-            {
-              "id": "28ab3eb4-f923-4ea0-a434-9d831bdd9a42",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 176.1704559326172,
-              "name": "in-1",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [
-                "b2662d1e-aa22-47c3-abe7-d9920a346a2e"
-              ],
-              "in": true,
-              "label": "model_file_path"
-            },
-            {
-              "id": "0d19d1d9-21a7-4c66-a8e2-fa65f77509a9",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 192.1704559326172,
-              "name": "parameter-string-in-2",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [],
-              "in": true,
-              "label": "model_name"
-            },
-            {
-              "id": "a9446860-5f11-41f5-9279-a2e0df581424",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 208.1704559326172,
-              "name": "parameter-string-in-3",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [],
-              "in": true,
-              "label": "creator_name"
-            },
-            {
-              "id": "0fdf1e33-7a88-436d-a6af-7048aba345f8",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 224.17047119140625,
-              "name": "parameter-string-in-4",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [
-                "3e312605-b1b9-427f-9c0c-d58a522e4a36"
-              ],
-              "in": true,
-              "label": "training_dataset_name"
-            },
-            {
-              "id": "2cdd1416-3ec4-4272-bc98-2e8b81c230f1",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 240.17047119140625,
-              "name": "in-5",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [],
-              "in": true,
-              "label": "input_names"
-            },
-            {
-              "id": "1a963499-d055-4603-9b27-78c1e47db1b2",
-              "type": "default",
-              "x": 1407.977294921875,
-              "y": 256.17047119140625,
-              "name": "in-6",
-              "alignment": "left",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [],
-              "in": true,
-              "label": "output_names"
-            },
-            {
-              "id": "7852fcbc-a717-48fe-a27e-9a970bbe8c72",
-              "type": "default",
-              "x": 1615.57958984375,
-              "y": 160.1704559326172,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [
-                "ebf0d808-58cd-42a2-b71e-e54559f7765b"
-              ],
-              "in": false,
-              "label": "▶"
-            },
-            {
-              "id": "27457f61-53fd-4483-8345-29ef7593bd2b",
-              "type": "default",
-              "x": 1615.57958984375,
-              "y": 176.1704559326172,
-              "name": "out-1",
-              "alignment": "right",
-              "parentNode": "dc037fda-aef3-4d34-89ce-1396b1b5c1fe",
-              "links": [],
-              "in": false,
-              "label": "ms_model"
-            }
-          ],
-          "name": "UploadToModelStash",
-          "color": "rgb(102,51,102)",
-          "portsInOrder": [
-            "06cabd36-1462-4145-8461-0ecde0f02199",
-            "28ab3eb4-f923-4ea0-a434-9d831bdd9a42",
-            "0d19d1d9-21a7-4c66-a8e2-fa65f77509a9",
-            "a9446860-5f11-41f5-9279-a2e0df581424",
-            "0fdf1e33-7a88-436d-a6af-7048aba345f8",
-            "2cdd1416-3ec4-4272-bc98-2e8b81c230f1",
-            "1a963499-d055-4603-9b27-78c1e47db1b2"
-          ],
-          "portsOutOrder": [
-            "7852fcbc-a717-48fe-a27e-9a970bbe8c72",
-            "27457f61-53fd-4483-8345-29ef7593bd2b"
-          ]
-        },
-        "f42ed9b4-f8c2-48fd-a1ee-366474d8e666": {
-          "id": "f42ed9b4-f8c2-48fd-a1ee-366474d8e666",
-          "type": "custom-node",
-          "extras": {
-            "type": "int",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 400.03372175696126,
-          "y": 188.99485923650744,
-          "ports": [
-            {
-              "id": "929e94e1-0e7c-450a-bdb3-2af34880a8a9",
-              "type": "default",
-              "x": 477.2841033935547,
-              "y": 216.125,
-              "name": "out-0",
-              "alignment": "right",
-              "parentNode": "f42ed9b4-f8c2-48fd-a1ee-366474d8e666",
-              "links": [
-                "c8c99aac-5162-4e64-83b3-d40f66defa3a"
-              ],
-              "in": false,
-              "label": "5"
-            }
-          ],
-          "name": "Literal Integer",
-          "color": "rgb(204,204,204)",
-          "portsInOrder": [],
-          "portsOutOrder": [
-            "929e94e1-0e7c-450a-bdb3-2af34880a8a9"
-          ]
-        },
-        "66344a48-55c3-4851-a022-b579cf0acfe3": {
-          "id": "66344a48-55c3-4851-a022-b579cf0acfe3",
-          "type": "custom-node",
-          "extras": {
-            "type": "string",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 959.792926303096,
-          "y": 275.39863517956076,
-          "ports": [
-            {
-              "id": "eb5d0a0b-06f3-4533-a2c6-9d40597ec8da",
-              "type": "default",
-              "x": 1162.3068237304688,
-              "y": 302.5340881347656,
-              "name": "parameter-out-0",
-              "alignment": "right",
-              "parentNode": "66344a48-55c3-4851-a022-b579cf0acfe3",
-              "links": [
-                "00e79a61-f3c9-42dd-a18b-b838ba946f9c"
-              ],
-              "in": false,
-              "label": "▶"
-            }
-          ],
-          "name": "Hyperparameter (String): ms_password",
-          "color": "rgb(255,153,102)",
-          "portsInOrder": [],
-          "portsOutOrder": [
-            "eb5d0a0b-06f3-4533-a2c6-9d40597ec8da"
-          ]
-        },
-        "5eeaece6-7beb-46f1-b50d-aadcdcb434d2": {
-          "id": "5eeaece6-7beb-46f1-b50d-aadcdcb434d2",
-          "type": "custom-node",
-          "extras": {
-            "type": "string",
-            "borderColor": "rgb(0,192,255)"
-          },
-          "x": 984.6327346448701,
-          "y": 222.6877968553984,
-          "ports": [
-            {
-              "id": "28ceb49d-924d-4ec4-8eeb-8f9b9a00259b",
-              "type": "default",
-              "x": 1161.4659423828125,
-              "y": 249.81817626953125,
-              "name": "parameter-out-0",
-              "alignment": "right",
-              "parentNode": "5eeaece6-7beb-46f1-b50d-aadcdcb434d2",
-              "links": [
-                "8eca32d4-52a3-4b28-8df0-6d51a35bdabb"
-              ],
-              "in": false,
-              "label": "▶"
-            }
-          ],
-          "name": "Hyperparameter (String): ms_user",
-          "color": "rgb(255,153,102)",
-          "portsInOrder": [],
-          "portsOutOrder": [
-            "28ceb49d-924d-4ec4-8eeb-8f9b9a00259b"
-          ]
-        }
-      }
-    }
-  ]
+    ]
 }

--- a/src/components/xpipeBodyWidget.tsx
+++ b/src/components/xpipeBodyWidget.tsx
@@ -455,7 +455,8 @@ export const BodyWidget: FC<BodyWidgetProps> = ({
 												pythonCode += '    ' + bindingName + '.' + label + '.value = ' + sourcePortLabel + "\n";
 											}
 										  // Make sure the node id match between connected link and source node
-										} else if (linkSourceNodeId == sourceNodeId) {
+										  // Skip Hyperparameter Components
+										} else if (linkSourceNodeId == sourceNodeId && !sourceNodeName.startsWith("Hyperparameter")) {
 											pythonCode += '    ' + bindingName + '.' + label + ' = ' + preBindingName + '.' + sourcePortLabel + '\n';
 										} else {
 											sourcePortLabel = sourcePortLabel.replace(/\s+/g, "_");

--- a/xai_components/xai_learning/training.py
+++ b/xai_components/xai_learning/training.py
@@ -400,21 +400,21 @@ class SaveKerasModel(Component):
 
     model: InArg[any]
     model_name: InArg[str]
-    model_h5: OutArg[str]
+    model_h5_path: OutArg[str]
 
     def __init__(self):
         self.done = False
         self.model = InArg.empty()
         self.model_name = InArg.empty()
 
-        self.model_h5 = OutArg.empty()
+        self.model_h5_path = OutArg.empty()
 
     def execute(self) -> None:
         model = self.model.value
         model_name = self.model_name.value if self.model_name.value else os.path.splitext(sys.argv[0])[0] + ".h5"
         model.save(model_name)
         print(f"Saving Keras h5 model at: {model_name}")
-        self.model_h5.value = model_name
+        self.model_h5_path.value = model_name
 
         self.done = True
 

--- a/xai_components/xai_learning/training.py
+++ b/xai_components/xai_learning/training.py
@@ -247,11 +247,15 @@ class Create2DInputModel(Component):
     training_data: InArg[Tuple[np.array, np.array]]
 
     model: OutArg[keras.Sequential]
+    model_config: OutArg[dict]
+
 
     def __init__(self):
         self.done = False
         self.training_data = InArg.empty()
         self.model = OutArg.empty()
+        self.model_config = OutArg.empty()
+
 
     def execute(self) -> None:
 
@@ -279,35 +283,55 @@ class Create2DInputModel(Component):
             metrics=['accuracy']
         )
 
+        model_config = {
+            'lr': model.optimizer.lr.numpy().item(),
+            'optimizer_name': model.optimizer._name,
+            'loss': model.loss,
+        }
+
         self.model.value = model
+        self.model_config.value = model_config
+
         self.done = True
 
 
 @xai_component(type="train")
 class TrainImageClassifier(Component):
+    model: InArg[keras.Sequential]
     training_data: InArg[Tuple[np.array, np.array]]
     training_epochs: InArg[int]
-    model: InArg[keras.Sequential]
 
     trained_model: OutArg[keras.Sequential]
+    training_metrics: OutArg[dict]
 
     def __init__(self):
         self.done = False
+
+        self.model = InArg.empty()
         self.training_data = InArg.empty()
         self.training_epochs = InArg.empty()
-        self.model = InArg.empty()
         self.trained_model = OutArg.empty()
+        self.training_metrics = OutArg.empty()
 
     def execute(self) -> None:
 
-        self.model.value.fit(
+        model = self.model.value
+
+        train = model.fit(
             self.training_data.value[0],
             self.training_data.value[1],
             batch_size=32,
             epochs=self.training_epochs.value
         )
 
-        self.trained_model.value = self.model.value
+        # Set training metrics
+        training_metrics = {}
+        for key in train.history.keys():
+            training_metrics[key] = {}
+            [training_metrics[key].update({i + 1: v}) for i, v in enumerate(train.history[key])]
+
+        self.trained_model.value = model
+        self.training_metrics.value = training_metrics
         self.done = True
 
 

--- a/xai_components/xai_modelstash/modelstash_core.py
+++ b/xai_components/xai_modelstash/modelstash_core.py
@@ -163,7 +163,7 @@ class UploadToModelStash(Component):
 
 
         else:
-
+            print(f"Base model {model_name} not found! Creating base model...")
             base_model = ms.create_model(file_path=model_file_path, 
                                             model_name=model_name, 
                                             created_by=creator_name, 


### PR DESCRIPTION
# Description

The previous modelstash pull request #70 created components for local modelstash deployment. This pull request updates the library when in performing modelstash operations in Konsole (you do not need to specify a session user & password). 
 
I have also updated the `UploadToModelStash` component so that it uploads the model as a model version if say a base model has been created already. 

## Pull Request Type

- [ ] Xpipes Core (Jupyterlab Related changes)
- [ ] Xpipes Canvas (Custom RD Related changes)
- [x] Xpipes Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Basic Sanity Check
Run a simple `ListModel` component in local and inside Konsole. Don't forget if you're running it local you'll need to use the `StartLocalModelstashSession` component. 

2. Test UploadtoModelstash Component
I have updated the MSTrainUpload.xpipes example. Simply run it multiple times, and check in modelstash whether it properly logs the evaluation comparison. Try it in local and in Konsole, where in Konsole you would need to delete the `StartLocalModelstashSession` component and reconnect the triangles appropriately.

Expected Output:

```
Executing: SaveKerasModel
Saving Keras h5 model at: examples/MSTrainUpload.h5

Executing: StartLocalModelStashSession

Executing: UploadToModelStash
MODELSTASH UPLOAD PARAMETERS:
model_file_path='examples/MSTrainUpload.h5'
model_name='MSTrainUpload'
creator_name='Fahreza'
training_dataset_name='MSTrainUpload_dataset'
input_names=['MSTrainUpload_input']
output_names=['MSTrainUpload_output']
model_config={'lr': 0.0010000000474974513, 'optimizer_name': 'Adam', 'loss': 'categorical_crossentropy'}
training_metric={'loss': {1: 0.48325178027153015, 2: 0.1595751792192459}, 'accuracy': {1: 0.8528571724891663, 2: 0.951285719871521}}
evaluation_metric={'loss': '0.10675671696662903', 'accuracy': '0.9683214426040649'}

Searching for existing MSTrainUpload in modelstash...
Base model MSTrainUpload found!
examples/MSTrainUpload.h5: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 445k/445k [00:00<00:00, 10.6MB/s]
```



## Tested on?

- [x] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [x] Others  (State here -> Konsole)  

