### PR TITLE
🐛 Fix initialize hyperparameter when opening xircuits

### DIFF
--- a/src/xircuitWidget.tsx
+++ b/src/xircuitWidget.tsx
@@ -62,8 +62,7 @@ export class XPipePanel extends ReactWidget {
     this.stepOutDebugSignal = options.stepOutDebugSignal;
     this.evaluateDebugSignal = options.evaluateDebugSignal;
     this.debugModeSignal = options.debugModeSignal;
-    var xircuitsApp = new XircuitsApplication();
-    this.xircuitsApp = xircuitsApp;
+    this.xircuitsApp = new XircuitsApplication();
   }
 
   handleEvent(event: Event): void {


### PR DESCRIPTION
# Description

Fix Hyperparameter prompt does not appear when first running xircuits. 

## Pull Request Type

- [ ] Xircuits Core (Jupyterlab Related changes)
- [x] Xircuits Canvas (Custom RD Related changes)
- [ ] Xircuits Component Library
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

1. Create and run xircuits which have hyperparameter components
   1. Create a new xircuits
   2. Make a simple working xircuits which include Hyperparameter
   3. Close & open the xircuits
   4. Run the opened xircuits
   5. Is the hyperparameter prompt shown correctly?
2. Run any xircuits in `/examples` which have Hyperparameter components
   1. Is the hyperparameter prompt shown correctly?


## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Still working on fixing initializing hyperparameter prompt when in `dirty` state.
